### PR TITLE
feat: migrate generation pipeline to openrouter

### DIFF
--- a/ai_influencer/README.md
+++ b/ai_influencer/README.md
@@ -1,10 +1,10 @@
-# AI Influencer — Hybrid Pro (Leonardo.ai + Locale)
+# AI Influencer — Hybrid Pro (OpenRouter + Locale)
 
 Pipeline per generare un dataset (da 2 foto iniziali a ~100+ immagini), verificare qualità, fare augment e addestrare un LoRA SDXL.
 
 ## Requisiti
 - Windows + Docker Desktop + GPU NVIDIA (es. RTX 4070)
-- Account Leonardo.ai (per generazione remota) — [Unverified] verifica termini/licenza correnti.
+- Account OpenRouter (LLM + Images) — [Unverified] controlla limiti/licenza correnti.
 - Modello SDXL base (metti il file in `models/base/sdxl.safetensors`).
 
 ## Setup rapido
@@ -18,25 +18,29 @@ Pipeline per generare un dataset (da 2 foto iniziali a ~100+ immagini), verifica
    docker exec -it ai_influencer_tools bash
    python3 scripts/prepare_dataset.py --in data/input_raw --out data/cleaned --do_rembg --do_facecrop
    ```
-4. Leonardo batch (aggiorna endpoint/parametri nello script se servono) e esporta la chiave:
+4. Generazione testi creativi (storyboard/script/caption seed) con OpenRouter LLM:
    ```bash
-   export LEONARDO_API_KEY=YOUR_KEY
-   python3 scripts/leonardo_batch.py --prompt_bank scripts/prompt_bank.yaml --out data/synth_leonardo
+   export OPENROUTER_API_KEY=YOUR_KEY
+   python3 scripts/openrouter_text.py --prompt_bank scripts/prompt_bank.yaml --out data/text/storyboard.json
    ```
-5. Controllo qualità:
+5. Genera immagini con l'API Images di OpenRouter (scegli il modello, es. `stabilityai/sdxl` o `black-forest-labs/flux`):
    ```bash
-   python3 scripts/qc_face_sim.py --ref data/cleaned --cand data/synth_leonardo --out data/qc_passed --minsim 0.34
+   python3 scripts/openrouter_images.py --prompt_bank scripts/prompt_bank.yaml --out data/synth_openrouter --model stabilityai/sdxl
    ```
-6. Augment + caption:
+6. Controllo qualità:
    ```bash
-   python3 scripts/augment_and_caption.py --in data/qc_passed --out data/augment --captions data/captions --num_aug 1 --meta data/synth_leonardo/manifest.json
+   python3 scripts/qc_face_sim.py --ref data/cleaned --cand data/synth_openrouter --out data/qc_passed --minsim 0.34
    ```
-7. Addestra LoRA (metti SDXL in `models/base/`):
+7. Augment + caption:
+   ```bash
+   python3 scripts/augment_and_caption.py --in data/qc_passed --out data/augment --captions data/captions --num_aug 1 --meta data/synth_openrouter/manifest.json
+   ```
+8. Addestra LoRA (metti SDXL in `models/base/`):
    ```bash
    docker exec -it kohya bash -lc "bash /workspace/scripts/train_lora.sh"
    ```
 
 ## Note
-- `leonardo_batch.py` è uno scheletro: aggiorna endpoint/parametri secondo la documentazione ufficiale Leonardo.ai.
+- `openrouter_text.py` e `openrouter_images.py` sono scheletri: aggiorna modello/parametri secondo la documentazione ufficiale OpenRouter.
 - La soglia `--minsim` va calibrata osservando i falsi positivi/negativi.
 - Mantieni 2–3 preset luce/scene come “firma” del brand per la coerenza.

--- a/ai_influencer/scripts/openrouter_images.py
+++ b/ai_influencer/scripts/openrouter_images.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Batch image generation using the OpenRouter Images API.
+
+The original tooling downloaded renders from Leonardo.ai.  This
+replacement keeps the surrounding dataset/QC pipeline intact while
+swapping the backend for OpenRouter-hosted diffusion models (e.g. SDXL,
+Flux, etc.).  Prompts are produced from the same YAML prompt bank to
+preserve creative direction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+import yaml
+
+
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+
+
+def sha(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:8]
+
+
+def request_image(model: str, prompt: str, negative_prompt: str | None, size: str) -> Dict[str, Any]:
+    if not OPENROUTER_API_KEY:
+        raise RuntimeError("Set OPENROUTER_API_KEY environment variable")
+
+    url = f"{OPENROUTER_BASE_URL}/images"
+    headers = {
+        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": os.getenv("OPENROUTER_APP_URL", "https://localhost"),
+        "X-Title": os.getenv("OPENROUTER_APP_TITLE", "AI Influencer Pipeline"),
+    }
+    payload: Dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "size": size,
+    }
+    if negative_prompt:
+        payload["negative_prompt"] = negative_prompt
+
+    response = requests.post(url, headers=headers, json=payload, timeout=120)
+    response.raise_for_status()
+    return response.json()
+
+
+def extract_image_bytes(response: Dict[str, Any]) -> bytes:
+    data = response.get("data")
+    if not data:
+        raise RuntimeError(f"No image data returned: {response}")
+    blob = data[0]
+    if "b64_json" in blob:
+        return base64.b64decode(blob["b64_json"])
+    if "url" in blob:
+        download = requests.get(blob["url"], timeout=120)
+        download.raise_for_status()
+        return download.content
+    raise RuntimeError(f"Unsupported image payload: {blob}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate images via OpenRouter Images API")
+    parser.add_argument("--prompt_bank", required=True, help="YAML prompt bank with persona/scenes")
+    parser.add_argument("--out", required=True, help="Output directory for generated images")
+    parser.add_argument("--model", default="stabilityai/sdxl", help="OpenRouter image model ID")
+    parser.add_argument("--size", default="1024x1024", help="Image resolution, e.g. 1024x1024")
+    parser.add_argument("--per_scene", type=int, default=12, help="Images to sample per scene preset")
+    parser.add_argument("--sleep", type=float, default=3.0, help="Seconds to wait between requests")
+    args = parser.parse_args()
+
+    with open(args.prompt_bank, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    persona: str = cfg.get("persona", "AI influencer")
+    negatives: str = cfg.get("negatives", "")
+    scenes = cfg.get("scenes", [])
+    lighting = cfg.get("lighting", [])
+    poses = cfg.get("poses", [])
+    outfits = cfg.get("outfits", [])
+    focals = cfg.get("focals", [])
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest: Dict[str, Any] = {}
+
+    for scene in scenes:
+        for idx in range(args.per_scene):
+            pose = poses[idx % len(poses)] if poses else ""
+            outfit = outfits[idx % len(outfits)] if outfits else ""
+            focal = focals[idx % len(focals)] if focals else ""
+            light = lighting[idx % len(lighting)] if lighting else ""
+            prompt = (
+                f"{persona}\n"
+                f"Scene: {scene}\n"
+                f"Pose: {pose}\n"
+                f"Outfit: {outfit}\n"
+                f"Lighting: {light}\n"
+                f"Optics: {focal}, shallow depth of field, photo-realistic, 8k render."
+            )
+
+            try:
+                response = request_image(args.model, prompt, negatives, args.size)
+                image_bytes = extract_image_bytes(response)
+                name = sha(prompt + str(idx))
+                out_file = out_dir / f"{name}.png"
+                with out_file.open("wb") as f:
+                    f.write(image_bytes)
+                manifest[name] = {
+                    "scene": scene,
+                    "pose": pose,
+                    "outfit": outfit,
+                    "focal": focal,
+                    "lighting": light,
+                    "prompt": prompt,
+                    "model": args.model,
+                    "size": args.size,
+                }
+                print(f"[openrouter] saved {out_file}")
+            except Exception as exc:
+                print(f"[error] {exc}")
+
+            time.sleep(max(args.sleep, 0.0))
+
+    manifest_path = out_dir / "manifest.json"
+    with manifest_path.open("w", encoding="utf-8") as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+    print(f"Manifest written to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/ai_influencer/scripts/openrouter_text.py
+++ b/ai_influencer/scripts/openrouter_text.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate storyboard, script and caption seeds using OpenRouter chat models.
+
+The previous pipeline relied on Leonardo.ai for both text prompts and
+image generation.  This module replaces the text generation portion with
+an OpenRouter-first approach: it queries an OpenRouter-hosted large
+language model and persists the returned structured data locally so that
+the downstream steps (captioning, TTS metadata, etc.) can continue to
+operate unchanged.
+
+Example usage::
+
+    export OPENROUTER_API_KEY=sk-or-v1-...
+    python3 scripts/openrouter_text.py \
+        --prompt_bank scripts/prompt_bank.yaml \
+        --out data/text/storyboard.json
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+import yaml
+
+
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+
+
+SYSTEM_PROMPT = (
+    "You are an experienced creative director for short-form social media "
+    "videos.  Given persona details and creative levers you must produce a "
+    "concise storyboard, a spoken script and at least 5 caption seeds.  "
+    "Return strict JSON with the following schema: {\"storyboard\": [" 
+    "{\"scene\": str, \"beats\": [str]}], \"script\": str, "
+    "\"caption_seeds\": [str]}"
+)
+
+
+def call_openrouter(model: str, messages: list[dict[str, str]], max_tokens: int = 600) -> str:
+    if not OPENROUTER_API_KEY:
+        raise RuntimeError("Set OPENROUTER_API_KEY environment variable")
+
+    url = f"{OPENROUTER_BASE_URL}/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+        "Content-Type": "application/json",
+        # The following headers are recommended by OpenRouter for rate-limit fairness.
+        "HTTP-Referer": os.getenv("OPENROUTER_APP_URL", "https://localhost"),
+        "X-Title": os.getenv("OPENROUTER_APP_TITLE", "AI Influencer Pipeline"),
+    }
+    payload = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "temperature": 0.7,
+        "messages": messages,
+    }
+    response = requests.post(url, headers=headers, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    try:
+        return data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError) as exc:  # pragma: no cover - defensive
+        raise RuntimeError(f"Malformed response from OpenRouter: {data}") from exc
+
+
+def build_prompt(persona: str, prompt_bank: Dict[str, Any]) -> str:
+    scenes = prompt_bank.get("scenes", [])
+    lighting = prompt_bank.get("lighting", [])
+    poses = prompt_bank.get("poses", [])
+    outfits = prompt_bank.get("outfits", [])
+    focals = prompt_bank.get("focals", [])
+
+    return (
+        "You are provided with persona and stylistic controls for an AI influencer.\n" \
+        f"Persona: {persona}\n" \
+        f"Scene presets: {scenes}\n" \
+        f"Lighting options: {lighting}\n" \
+        f"Poses: {poses}\n" \
+        f"Outfits: {outfits}\n" \
+        f"Focal lengths: {focals}.\n" \
+        "Create a storyboard of 4-6 scenes referencing the presets, a 90-second "
+        "script aligned with the storyboard, and concise caption seeds suitable "
+        "for social media (10-15 words each)."
+    )
+
+
+def save_json(data: Dict[str, Any], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate storyboard/script using OpenRouter")
+    parser.add_argument("--prompt_bank", required=True, help="YAML file with persona and style levers")
+    parser.add_argument("--model", default="meta-llama/llama-3.1-70b-instruct", help="OpenRouter chat model ID")
+    parser.add_argument("--out", required=True, help="Destination JSON file")
+    args = parser.parse_args()
+
+    with open(args.prompt_bank, "r", encoding="utf-8") as f:
+        prompt_bank = yaml.safe_load(f)
+
+    persona = prompt_bank.get("persona", "AI influencer")
+    user_prompt = build_prompt(persona, prompt_bank)
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    raw = call_openrouter(args.model, messages)
+
+    try:
+        parsed: Dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "The OpenRouter response was not valid JSON. "
+            "Adjust the prompt or inspect the raw output."
+        ) from exc
+
+    save_json(parsed, Path(args.out))
+    print(f"Saved OpenRouter text plan to {args.out}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- switch the project documentation to an OpenRouter-first workflow for text and image generation
- add an OpenRouter chat helper to build storyboard, script and caption seeds from the existing prompt bank
- introduce an OpenRouter Images batch generator that mirrors the former Leonardo pipeline and writes manifests compatible with downstream steps

## Testing
- python3 -m compileall scripts/openrouter_text.py scripts/openrouter_images.py

------
https://chatgpt.com/codex/tasks/task_e_68d551f0a938832090fd843a539aa733