### PR TITLE
Fix OpenRouter test script paths

### DIFF
--- a/ai_influencer/docker/docker-compose.yaml
+++ b/ai_influencer/docker/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ../data:/workspace/data
       - ../scripts:/workspace/scripts
+      - ../scripts:/scripts
     command: >
       bash -lc "
       apt-get update &&

--- a/ai_influencer/scripts/test_openrouter_chat.py
+++ b/ai_influencer/scripts/test_openrouter_chat.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Quick connectivity check against the OpenRouter chat completions API."""
+from __future__ import annotations
+
+import os
+import sys
+
+import requests
+
+
+def main() -> None:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        sys.exit("OPENROUTER_API_KEY mancante")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "http://localhost",
+        "X-Title": "ai-influencer",
+    }
+    payload = {
+        "model": "openai/gpt-4o-mini",
+        "messages": [{"role": "user", "content": "scrivi: ok"}],
+    }
+
+    response = requests.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        headers=headers,
+        json=payload,
+        timeout=60,
+    )
+    print("HTTP:", response.status_code)
+    print(response.text[:600])
+
+
+if __name__ == "__main__":
+    main()

--- a/ai_influencer/scripts/test_openrouter_image.py
+++ b/ai_influencer/scripts/test_openrouter_image.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Quick connectivity check against the OpenRouter image generation API."""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import pathlib
+import sys
+import urllib.request
+
+import requests
+
+
+def main() -> None:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        sys.exit("OPENROUTER_API_KEY mancante")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "HTTP-Referer": "http://localhost",
+        "X-Title": "ai-influencer",
+    }
+    payload = {
+        "model": "stability-ai/stable-diffusion-xl-base-1.0",
+        "prompt": "portrait photorealistic ai influencer, soft light, 50mm",
+        "width": 1024,
+        "height": 1024,
+    }
+
+    response = requests.post(
+        "https://openrouter.ai/api/v1/images",
+        headers=headers,
+        json=payload,
+        timeout=180,
+    )
+    print("HTTP:", response.status_code)
+    text = response.text
+    print(text[:600])
+    if not response.ok:
+        sys.exit(1)
+
+    data = response.json()
+    record = (data.get("data") or [{}])[0]
+
+    outdir = pathlib.Path("/workspace/data/synth_openrouter")
+    outdir.mkdir(parents=True, exist_ok=True)
+    filename = outdir / "test_openrouter.png"
+
+    if "b64_json" in record and record["b64_json"]:
+        filename.write_bytes(base64.b64decode(record["b64_json"]))
+        print("Saved:", filename)
+    elif "url" in record and record["url"]:
+        urllib.request.urlretrieve(record["url"], filename)
+        print("Saved:", filename)
+    else:
+        print("Payload inatteso:", json.dumps(data)[:400])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add python implementations for the OpenRouter chat and image smoke tests under scripts/
- mount the scripts directory at /scripts in the tools container so the documented docker compose commands work

## Testing
- python3 -m compileall scripts/test_openrouter_chat.py scripts/test_openrouter_image.py

------
https://chatgpt.com/codex/tasks/task_e_68d57994b8408320b4966ddba30f925a