### PR TITLE
Ensure python3 installed in tools container

### DIFF
--- a/ai_influencer/docker/docker-compose.yaml
+++ b/ai_influencer/docker/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     command: >
       bash -lc "
       apt-get update &&
-      apt-get install -y python3-pip git &&
+      apt-get install -y python3 python3-pip git &&
       pip3 install --no-cache-dir -r /workspace/scripts/requirements.txt &&
       tail -f /dev/null
       "


### PR DESCRIPTION
## Summary
- install the python3 package in the tools service to guarantee the python3 executable is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d57ad1b0f0832089b9de960f836fbf