### PR TITLE
Handle non-JSON responses from OpenRouter test

### DIFF
--- a/ai_influencer/docker/docker-compose.yaml
+++ b/ai_influencer/docker/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     command: >
       bash -lc "
       apt-get update &&
-      apt-get install -y python3-pip git &&
+      apt-get install -y python3 python3-pip git &&
       pip3 install --no-cache-dir -r /workspace/scripts/requirements.txt &&
       tail -f /dev/null
       "

--- a/ai_influencer/scripts/test_openrouter_image.py
+++ b/ai_influencer/scripts/test_openrouter_image.py
@@ -20,6 +20,7 @@ def main() -> None:
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
+        "Accept": "application/json",
         "HTTP-Referer": "http://localhost",
         "X-Title": "ai-influencer",
     }
@@ -42,7 +43,22 @@ def main() -> None:
     if not response.ok:
         sys.exit(1)
 
-    data = response.json()
+    content_type = response.headers.get("Content-Type", "")
+    if "json" not in content_type:
+        print(
+            "Unexpected response Content-Type:",
+            content_type or "<missing>",
+        )
+        print("First 400 characters of body:")
+        print(text[:400])
+        sys.exit(1)
+
+    try:
+        data = response.json()
+    except (json.JSONDecodeError, requests.exceptions.JSONDecodeError):
+        print("Unable to decode JSON response. First 400 characters:")
+        print(text[:400])
+        sys.exit(1)
     record = (data.get("data") or [{}])[0]
 
     outdir = pathlib.Path("/workspace/data/synth_openrouter")


### PR DESCRIPTION
## Summary
- ensure the OpenRouter connectivity check requests JSON responses
- add defensive handling so non-JSON responses exit cleanly with context
- guard JSON parsing behind a Content-Type check and catch decode errors to avoid tracebacks when HTML is returned

## Testing
- python3 -m compileall ai_influencer/scripts/test_openrouter_image.py

------
https://chatgpt.com/codex/tasks/task_e_68d57ad1b0f0832089b9de960f836fbf