### PR TITLE
Install build dependencies for webapp service

### DIFF
--- a/ai_influencer/docker/docker-compose.yaml
+++ b/ai_influencer/docker/docker-compose.yaml
@@ -61,6 +61,13 @@ services:
     working_dir: /workspace
     volumes:
       - ../:/workspace
-    command: bash -lc "pip install --no-cache-dir -r ai_influencer/webapp/requirements.txt && uvicorn ai_influencer.webapp.main:app --host 0.0.0.0 --port 8000"
+    command: >
+      bash -lc "
+      apt-get update && \
+      apt-get install -y --no-install-recommends build-essential python3-dev && \
+      rm -rf /var/lib/apt/lists/* && \
+      pip install --no-cache-dir -r ai_influencer/webapp/requirements.txt && \
+      uvicorn ai_influencer.webapp.main:app --host 0.0.0.0 --port 8000
+      "
     ports:
       - "8000:8000"


### PR DESCRIPTION
## Summary
- update the docker compose webapp command to install build-essential and python3-dev before pip installs
- clean up apt caches to keep the container lean while ensuring python packages with native extensions can build

## Testing
- not run (docker is unavailable in the current environment)


------
https://chatgpt.com/codex/tasks/task_e_68d697eeb3dc8320a6c720d17761d7aa