### PR TITLE
Add tests for FastAPI models endpoint dependency overrides

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,11 +1,82 @@
 """Tests for the FastAPI web application endpoints."""
 
+import pathlib
+import sys
+
 from fastapi.testclient import TestClient
 
-from ai_influencer.webapp.main import app
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ai_influencer.webapp.main import app, get_client
+from ai_influencer.webapp.openrouter import OpenRouterError, summarize_models
 
 
-client = TestClient(app)
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_list_models_returns_summarized_payload_and_closes_client():
+    class StubClient:
+        def __init__(self) -> None:
+            self.close_called = False
+            self.models = [
+                {
+                    "id": "openrouter/model-1",
+                    "name": "Model One",
+                    "owned_by": "openrouter",
+                    "context_length": 8192,
+                    "pricing": {"input": "0.0005", "output": "0.001"},
+                    "architecture": {"modality": ["text", "image"]},
+                },
+                {
+                    "id": "openrouter/model-2",
+                    "name": "Model Two",
+                    "owned_by": "openrouter",
+                    "pricing": {"video": "0.01"},
+                    "tags": ["beta"],
+                },
+            ]
+
+        async def list_models(self):
+            return self.models
+
+        async def close(self):
+            self.close_called = True
+
+    stub_client = StubClient()
+    app.dependency_overrides[get_client] = lambda: stub_client
+    try:
+        response = client.get("/api/models")
+    finally:
+        app.dependency_overrides.pop(get_client, None)
+
+    assert response.status_code == 200
+    assert response.json() == {"models": summarize_models(stub_client.models)}
+    assert stub_client.close_called is True
+
+
+def test_list_models_handles_openrouter_error_and_closes_client():
+    class ErrorStubClient:
+        def __init__(self) -> None:
+            self.close_called = False
+
+        async def list_models(self):
+            raise OpenRouterError("Unable to fetch")
+
+        async def close(self):
+            self.close_called = True
+
+    stub_client = ErrorStubClient()
+    app.dependency_overrides[get_client] = lambda: stub_client
+    try:
+        response = client.get("/api/models")
+    finally:
+        app.dependency_overrides.pop(get_client, None)
+
+    assert response.status_code == 500
+    assert response.text == "Internal Server Error"
+    assert stub_client.close_called is True
 
 
 def test_influencer_lookup_returns_enriched_media():


### PR DESCRIPTION
## Summary
- add stubbed client tests that inject dependency overrides for /api/models to validate success responses and resource cleanup
- cover the error path to confirm OpenRouter failures surface as 500 responses while still closing the client

## Testing
- pytest tests/test_webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c188a74883208a1c0849570a584f