### PR TITLE
Add regression tests for web UI and health endpoint

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -8,6 +8,30 @@ from ai_influencer.webapp.main import app
 client = TestClient(app)
 
 
+def test_homepage_serves_html():
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "AI Influencer Control Hub" in response.text
+
+
+def test_influencer_page_serves_html():
+    response = client.get("/influencer")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "Analisi Influencer" in response.text
+
+
+def test_health_check():
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {"status": "ok"}
+
+
 def test_influencer_lookup_returns_enriched_media():
     response = client.post(
         "/api/influencer",


### PR DESCRIPTION
## Summary
- add lightweight regression tests covering the homepage and influencer HTML routes
- add a health-check test ensuring the /healthz endpoint returns the expected JSON payload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c1a90e7c83209832bf2a51d526e4