### PR TITLE
feat: allow choosing base model for LoRA training

### DIFF
--- a/ai_influencer/README.md
+++ b/ai_influencer/README.md
@@ -13,6 +13,7 @@ Questo documento accompagna la cartella `ai_influencer/` e descrive nel dettagli
   - [4. Controllo qualità del dataset](#4-controllo-qualità-del-dataset)
   - [5. Augment + captioning](#5-augment--captioning)
   - [6. Addestramento LoRA SDXL](#6-addestramento-lora-sdxl)
+- [Gestione dei modelli base](#gestione-dei-modelli-base)
 - [Control Hub web](#control-hub-web)
 - [GUI desktop](#gui-desktop)
 - [Automazione via n8n](#automazione-via-n8n)
@@ -119,14 +120,21 @@ python3 scripts/augment_and_caption.py \
 - Mantiene l'originale e genera versioni `*_augX.jpg` a 95% qualità JPEG.
 - Produce caption descrittive utilizzando scena/luce/outfit dal manifest (fallback su valori predefiniti).
 
+## Gestione dei modelli base
+Salva uno o più checkpoint SDXL in `ai_influencer/models/base/` (estensione `.safetensors`). Puoi usare nomi diversi per distinguerli, es.: `sdxl.safetensors`, `dreamshaper_xl.safetensors`, `realvis_xl.safetensors`.
+
 ### 6. Addestramento LoRA SDXL
-Dal container `kohya_local`:
+Dal container `kohya_local` puoi specificare il modello da usare con il flag `--base-model`:
 ```bash
-docker exec -it kohya_local bash -lc "bash /workspace/scripts/train_lora.sh"
+docker exec -it kohya_local bash -lc "bash /workspace/scripts/train_lora.sh --base-model /workspace/models/base/dreamshaper_xl.safetensors"
 ```
-- Lancia `accelerate` con `sd-scripts/train_network.py` (dim 32, alpha 16, risoluzione 1024).
-- `TRAIN_DIR=/workspace/data/augment` e `OUT_DIR=/workspace/models/lora` configurati nello script.
-- Il checkpoint LoRA viene salvato come `models/lora/influencer_lora.safetensors`.
+In alternativa esporta prima la variabile d'ambiente e invoca lo script normalmente:
+```bash
+docker exec -it kohya_local bash -lc "BASE_MODEL=/workspace/models/base/dreamshaper_xl.safetensors bash /workspace/scripts/train_lora.sh"
+```
+- Se non viene passato alcun valore, lo script usa `/workspace/models/base/sdxl.safetensors`.
+- Viene lanciato `accelerate` con `sd-scripts/train_network.py` (dim 32, alpha 16, risoluzione 1024) e gli output finiscono in `models/lora/`.
+- Log iniziale: `[train_lora] Modello base selezionato: ...` (utile come smoke test rapido per verificare che il parametro sia propagato).
 
 ## Control Hub web
 Il servizio FastAPI (`webapp/main.py`) gira nel container `ai_influencer_webapp` e offre:
@@ -156,7 +164,10 @@ python3 scripts/gui_app.py
 1. Riceve la richiesta HTTP.
 2. Esegue `python3 scripts/prepare_dataset.py ...` nel container tramite nodo `executeCommand`.
 3. Avvia `python3 scripts/openrouter_batch.py ...` per popolare `data/synth_openrouter`.
-4. (Ulteriori nodi possono essere collegati per QC/augment).
+4. Lancia `bash scripts/train_lora.sh`.
+5. (Ulteriori nodi possono essere collegati per QC/augment).
+
+Il nodo "Train LoRA" accetta nel payload JSON un campo opzionale `base_model` per inoltrare il percorso al flag `--base-model`; in assenza del campo viene usato il default `/workspace/models/base/sdxl.safetensors`.
 
 Importa il file in n8n, aggiorna percorsi/comandi in base alla tua infrastruttura Docker e proteggi il webhook con credenziali.
 

--- a/ai_influencer/n8n/flow.json
+++ b/ai_influencer/n8n/flow.json
@@ -64,7 +64,7 @@
     },
     {
       "parameters": {
-        "command": "bash scripts/train_lora.sh"
+        "command": "={{\"bash scripts/train_lora.sh\" + ($json[\"base_model\"] ? \" --base-model \\\"\" + $json[\"base_model\"] + \"\\\"\" : \"\")}}"
       },
       "name": "Train LoRA",
       "type": "n8n-nodes-base.executeCommand",

--- a/ai_influencer/scripts/train_lora.sh
+++ b/ai_influencer/scripts/train_lora.sh
@@ -1,15 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_MODEL="/workspace/models/base/sdxl.safetensors"
+BASE_MODEL_DEFAULT="/workspace/models/base/sdxl.safetensors"
+SELECTED_BASE_MODEL="${BASE_MODEL:-$BASE_MODEL_DEFAULT}"
 TRAIN_DIR="/workspace/data/augment"
 OUT_DIR="/workspace/models/lora"
 OUT_NAME="influencer_lora"
 
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-model)
+      if [[ $# -lt 2 ]]; then
+        echo "Errore: --base-model richiede un argomento" >&2
+        exit 1
+      fi
+      SELECTED_BASE_MODEL="$2"
+      shift 2
+      ;;
+    --base-model=*)
+      SELECTED_BASE_MODEL="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Utilizzo: train_lora.sh [--base-model <percorso_modello>] [argomenti aggiuntivi]
+
+  --base-model PATH   Percorso del checkpoint base da usare.
+                      Di default: /workspace/models/base/sdxl.safetensors
+
+È inoltre possibile impostare la variabile d'ambiente BASE_MODEL.
+Tutti gli argomenti non riconosciuti vengono inoltrati a train_network.py.
+EOF
+      exit 0
+      ;;
+    *)
+      EXTRA_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${SELECTED_BASE_MODEL}" ]]; then
+  echo "Errore: nessun modello base specificato." >&2
+  exit 1
+fi
+
+echo "[train_lora] Modello base selezionato: ${SELECTED_BASE_MODEL}"
+
 # ⬇️ usa lo script di sd-scripts
 accelerate launch \
   /opt/kohya_ss/sd-scripts/train_network.py \
-  --pretrained_model_name_or_path "${BASE_MODEL}" \
+  --pretrained_model_name_or_path "${SELECTED_BASE_MODEL}" \
   --train_data_dir "${TRAIN_DIR}" \
   --output_dir "${OUT_DIR}" \
   --output_name "${OUT_NAME}" \
@@ -20,4 +63,5 @@ accelerate launch \
   --lr_scheduler "cosine" --train_batch_size 2 \
   --max_train_steps 4000 \
   --mixed_precision "fp16" \
-  --save_every_n_steps 1000
+  --save_every_n_steps 1000 \
+  "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Summary
- add support in `train_lora.sh` for choosing the base checkpoint via `--base-model` or the `BASE_MODEL` environment variable and forward extra args
- expose the new parameter inside the n8n workflow and document how to manage multiple base checkpoints in the READMEs
- add a smoke-test note explaining how to confirm that the selected checkpoint is propagated

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6c24a438c8320aa782ea0105c37da