### PR TITLE
Add failure handling tests for OpenRouter client

### DIFF
--- a/tests/test_openrouter.py
+++ b/tests/test_openrouter.py
@@ -83,6 +83,21 @@ def test_list_models_refreshes_after_ttl_expiry() -> None:
     asyncio.run(scenario())
 
 
+def test_list_models_raises_on_failure_status() -> None:
+    transport = make_transport({"/models": httpx.Response(500, json={"error": "boom"})})
+
+    async def scenario() -> None:
+        client = OpenRouterClient(transport=transport)
+
+        try:
+            with pytest.raises(OpenRouterError):
+                await client.list_models()
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
 def test_generate_text_supports_chunked_content() -> None:
     transport = make_transport(
         {
@@ -146,6 +161,36 @@ def test_generate_image_returns_payload() -> None:
             await client.close()
 
         assert response == payload
+
+    asyncio.run(scenario())
+
+
+def test_generate_image_raises_on_failure_status() -> None:
+    transport = make_transport({"/images": httpx.Response(500, json={"error": "boom"})})
+
+    async def scenario() -> None:
+        client = OpenRouterClient(transport=transport)
+
+        try:
+            with pytest.raises(OpenRouterError):
+                await client.generate_image(model="demo", prompt="hi")
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())
+
+
+def test_generate_video_raises_on_failure_status() -> None:
+    transport = make_transport({"/videos": httpx.Response(500, json={"error": "boom"})})
+
+    async def scenario() -> None:
+        client = OpenRouterClient(transport=transport)
+
+        try:
+            with pytest.raises(OpenRouterError):
+                await client.generate_video(model="demo", prompt="hi")
+        finally:
+            await client.close()
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary
- add regression tests that use mocked transports to simulate 500 responses for models, images, and videos
- assert OpenRouterClient raises OpenRouterError for each failing endpoint

## Testing
- pytest tests/test_openrouter.py

------
https://chatgpt.com/codex/tasks/task_e_68d6cd2b572883209f178f10c0a9273d