### PR TITLE
Add OpenRouter configuration API and settings UI

### DIFF
--- a/ai_influencer/webapp/static/settings.js
+++ b/ai_influencer/webapp/static/settings.js
@@ -1,0 +1,115 @@
+function ensureToastContainer() {
+  let container = document.querySelector('.toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'toast-container';
+    document.body.appendChild(container);
+  }
+  return container;
+}
+
+function showToast(message, state = 'info') {
+  const container = ensureToastContainer();
+  const toast = document.createElement('div');
+  toast.className = `toast toast-${state}`;
+  toast.textContent = message;
+  container.appendChild(toast);
+  requestAnimationFrame(() => {
+    toast.classList.add('visible');
+  });
+  setTimeout(() => {
+    toast.classList.remove('visible');
+    setTimeout(() => {
+      toast.remove();
+      if (!container.childElementCount) {
+        container.remove();
+      }
+    }, 250);
+  }, 2000);
+}
+
+const statusEl = document.querySelector('#config-status');
+const form = document.querySelector('#openrouter-form');
+const apiKeyInput = document.querySelector('#openrouter-api-key');
+const baseUrlInput = document.querySelector('#openrouter-base-url');
+const clearButton = document.querySelector('#clear-settings');
+
+function renderStatus(payload) {
+  if (!statusEl) return;
+  statusEl.className = 'status-message';
+  const lines = [];
+  if (payload.has_api_key) {
+    const preview = payload.api_key_preview || '••••';
+    lines.push(`Chiave configurata: ${preview}`);
+  } else {
+    lines.push('Nessuna chiave configurata.');
+    statusEl.classList.add('empty');
+  }
+  if (payload.base_url) {
+    lines.push(`Endpoint personalizzato: ${payload.base_url}`);
+  }
+  statusEl.textContent = lines.join('\n');
+}
+
+async function loadConfig() {
+  if (!statusEl) return;
+  statusEl.textContent = 'Caricamento configurazione...';
+  statusEl.className = 'status-message loading';
+  try {
+    const response = await fetch('/api/config/openrouter');
+    if (!response.ok) {
+      throw new Error('Impossibile recuperare la configurazione');
+    }
+    const payload = await response.json();
+    renderStatus(payload);
+  } catch (error) {
+    statusEl.className = 'status-message error';
+    statusEl.textContent = error.message;
+  }
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  if (!form) return;
+  const apiKey = apiKeyInput?.value.trim() ?? '';
+  const baseUrl = baseUrlInput?.value.trim() ?? '';
+  const payload = {};
+  if (apiKey) payload.api_key = apiKey;
+  if (baseUrl) payload.base_url = baseUrl;
+  if (!payload.api_key && !payload.base_url) {
+    showToast('Inserisci almeno un valore da salvare', 'error');
+    return;
+  }
+  try {
+    const response = await fetch('/api/config/openrouter', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(data.detail || 'Salvataggio non riuscito');
+    }
+    renderStatus(data);
+    showToast('Configurazione aggiornata', 'success');
+    form.reset();
+    apiKeyInput?.focus();
+  } catch (error) {
+    showToast(error.message, 'error');
+    if (statusEl) {
+      statusEl.className = 'status-message error';
+      statusEl.textContent = error.message;
+    }
+  }
+}
+
+function handleClear() {
+  form?.reset();
+  apiKeyInput?.focus();
+  showToast('Modulo pulito', 'success');
+}
+
+form?.addEventListener('submit', handleSubmit);
+clearButton?.addEventListener('click', handleClear);
+
+loadConfig();

--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -287,6 +287,7 @@ textarea {
   border-radius: 12px;
   background: rgba(13, 17, 23, 0.6);
   border: 1px solid rgba(240, 246, 252, 0.08);
+  white-space: pre-line;
 }
 
 .status-message.loading {
@@ -436,6 +437,53 @@ textarea {
 .toast-error {
   border-color: rgba(255, 123, 114, 0.6);
   color: #ff7b72;
+}
+
+.settings-layout {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.settings-card {
+  gap: 1.25rem;
+}
+
+.settings-description {
+  margin: 0;
+  color: rgba(240, 246, 252, 0.75);
+}
+
+.settings-form .input-hint {
+  font-size: 0.8rem;
+  color: rgba(240, 246, 252, 0.6);
+}
+
+.settings-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.button-secondary {
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(240, 246, 252, 0.35);
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+.button-secondary:hover,
+.button-secondary:focus-visible {
+  background: rgba(240, 246, 252, 0.12);
+  border-color: rgba(240, 246, 252, 0.5);
+  outline: none;
 }
 
 @media (max-width: 900px) {

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -11,8 +11,15 @@
       <div class="header-bar">
         <h1>AI Influencer Control Hub</h1>
         <nav class="app-nav">
-          <a href="/">Generazione contenuti</a>
-          <a href="/influencer">Analisi influencer</a>
+          <a href="/"{% if active_nav == "home" %} aria-current="page"{% endif %}
+            >Generazione contenuti</a
+          >
+          <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
+            >Analisi influencer</a
+          >
+          <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
+            >Impostazioni</a
+          >
         </nav>
       </div>
       <p>

--- a/ai_influencer/webapp/templates/influencer.html
+++ b/ai_influencer/webapp/templates/influencer.html
@@ -11,8 +11,15 @@
       <div class="header-bar">
         <h1>Analisi Influencer</h1>
         <nav class="app-nav">
-          <a href="/">Generazione contenuti</a>
-          <a href="/influencer" aria-current="page">Analisi influencer</a>
+          <a href="/"{% if active_nav == "home" %} aria-current="page"{% endif %}
+            >Generazione contenuti</a
+          >
+          <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
+            >Analisi influencer</a
+          >
+          <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
+            >Impostazioni</a
+          >
         </nav>
       </div>
       <p>

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Impostazioni - AI Influencer Control Hub</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="header-bar">
+        <h1>Impostazioni</h1>
+        <nav class="app-nav">
+          <a href="/"{% if active_nav == "home" %} aria-current="page"{% endif %}
+            >Generazione contenuti</a
+          >
+          <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
+            >Analisi influencer</a
+          >
+          <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
+            >Impostazioni</a
+          >
+        </nav>
+      </div>
+      <p>
+        Gestisci la chiave API e l'endpoint di OpenRouter utilizzati dall'applicazione.
+        Le modifiche vengono salvate immediatamente nell'ambiente di esecuzione.
+      </p>
+    </header>
+
+    <main class="settings-layout">
+      <section class="card settings-card">
+        <h2>Configurazione OpenRouter</h2>
+        <p class="settings-description">
+          Inserisci la chiave API fornita da OpenRouter e, se necessario, un endpoint
+          personalizzato. La chiave viene mostrata in forma mascherata dopo il salvataggio.
+        </p>
+        <div id="config-status" class="status-message empty">
+          Nessuna chiave configurata.
+        </div>
+        <form id="openrouter-form" class="form settings-form" autocomplete="off">
+          <label>
+            Chiave API
+            <input
+              type="password"
+              id="openrouter-api-key"
+              name="api_key"
+              placeholder="sk-..."
+              autocomplete="off"
+            />
+            <span class="input-hint">
+              Il valore inviato sovrascrive quello attualmente configurato.
+            </span>
+          </label>
+          <label>
+            Endpoint personalizzato (facoltativo)
+            <input
+              type="url"
+              id="openrouter-base-url"
+              name="base_url"
+              placeholder="https://openrouter.ai/api/v1"
+              autocomplete="off"
+            />
+            <span class="input-hint">
+              Lascia vuoto per mantenere l'endpoint predefinito di OpenRouter.
+            </span>
+          </label>
+          <div class="settings-actions">
+            <button type="submit">Salva configurazione</button>
+            <button type="button" id="clear-settings" class="button-secondary">
+              Pulisci form
+            </button>
+          </div>
+        </form>
+      </section>
+    </main>
+
+    <script src="/static/settings.js" type="module"></script>
+  </body>
+</html>

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,6 +1,7 @@
 """Tests for the FastAPI web application endpoints."""
 
 import base64
+import os
 import pathlib
 import sys
 from pathlib import Path
@@ -174,6 +175,77 @@ def test_generate_image_returns_remote_url_and_closes_client():
         "is_remote": True,
     }
     assert stub_client.closed is True
+
+
+def test_get_openrouter_config_returns_masked_values(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-123456")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://api.openrouter.ai")
+
+    response = client.get("/api/config/openrouter")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["has_api_key"] is True
+    assert payload["api_key_preview"].endswith("3456")
+    assert set(payload["api_key_preview"].replace("3456", "")) == {"*"}
+    assert payload["base_url"] == "https://api.openrouter.ai"
+
+
+def test_update_openrouter_config_updates_environment(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    response = client.post(
+        "/api/config/openrouter",
+        json={
+            "api_key": "sk-new-9876",
+            "base_url": "https://example.com/api/v1",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert os.environ["OPENROUTER_API_KEY"] == "sk-new-9876"
+    assert os.environ["OPENROUTER_BASE_URL"] == "https://example.com/api/v1"
+    assert payload["has_api_key"] is True
+    assert payload["api_key_preview"].endswith("9876")
+    assert payload["updated"] == {
+        "api_key": True,
+        "base_url": "https://example.com/api/v1",
+    }
+
+
+def test_update_openrouter_config_allows_base_url_only(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-existing-2222")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    response = client.post(
+        "/api/config/openrouter", json={"base_url": "https://custom.example/api"}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert os.environ["OPENROUTER_API_KEY"] == "sk-existing-2222"
+    assert os.environ["OPENROUTER_BASE_URL"] == "https://custom.example/api"
+    assert payload["has_api_key"] is True
+    assert payload["base_url"] == "https://custom.example/api"
+    assert payload["api_key_preview"].endswith("2222")
+
+
+def test_update_openrouter_config_requires_payload():
+    response = client.post("/api/config/openrouter", json={})
+
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any("Provide at least one value" in err["msg"] for err in detail)
+
+
+def test_update_openrouter_config_validates_base_url():
+    response = client.post(
+        "/api/config/openrouter", json={"base_url": "not-a-valid-url"}
+    )
+
+    assert response.status_code == 422
 
 
 def test_generate_image_returns_inline_base64_and_closes_client():


### PR DESCRIPTION
## Summary
- add configuration endpoints for OpenRouter credentials with validation, masking, and environment updates
- introduce a settings page and client script to manage API keys with toast feedback and navigation updates
- extend styling and automated tests to cover the new configuration flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6db33a3b88320b255c5ba74301e62