### PR TITLE
Add pricing display to model cards

### DIFF
--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -134,6 +134,17 @@ body {
   color: rgba(240, 246, 252, 0.7);
 }
 
+.model-capabilities,
+.model-pricing {
+  font-size: 0.9rem;
+  color: rgba(240, 246, 252, 0.78);
+  line-height: 1.4;
+}
+
+.model-pricing {
+  font-style: italic;
+}
+
 .model-actions {
   display: flex;
   gap: 0.5rem;

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -114,6 +114,7 @@
           <span class="model-provider"></span>
         </div>
         <div class="model-capabilities"></div>
+        <div class="model-pricing"></div>
         <div class="model-actions">
           <button data-target="text-model">Usa per Testo</button>
           <button data-target="image-model">Usa per Immagini</button>


### PR DESCRIPTION
## Summary
- add a dedicated pricing row to the model card template and style it for readability
- compute human-readable pricing strings from OpenRouter pricing metadata and render them in the model list

## Testing
- pytest tests/test_webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e5c8cec88320bbf41b1d5a38a40d