### PR TITLE
Add pricing display metadata and surface in OpenRouter UI

### DIFF
--- a/ai_influencer/webapp/static/app.js
+++ b/ai_influencer/webapp/static/app.js
@@ -131,7 +131,12 @@ function renderModels(models) {
         ? model.capabilities.join(', ')
         : 'Sconosciute';
       clone.querySelector('.model-capabilities').textContent = `Capacità: ${capabilities}`;
-      clone.querySelector('.model-pricing').textContent = formatPricing(model.pricing);
+      const pricingElement = clone.querySelector('.model-pricing');
+      if (model.pricing_display) {
+        pricingElement.textContent = `Costo stimato: ${model.pricing_display}`;
+      } else {
+        pricingElement.textContent = formatPricing(model.pricing);
+      }
       clone.querySelectorAll('button[data-target]').forEach((btn) => {
         btn.addEventListener('click', () => {
           const target = document.querySelector(`#${btn.dataset.target}`);

--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -143,6 +143,7 @@ body {
 
 .model-pricing {
   font-style: italic;
+  min-height: 1.2rem;
 }
 
 .model-actions {

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -114,7 +114,7 @@
           <span class="model-provider"></span>
         </div>
         <div class="model-capabilities"></div>
-        <div class="model-pricing"></div>
+        <div class="model-pricing" aria-live="polite"></div>
         <div class="model-actions">
           <button data-target="text-model">Usa per Testo</button>
           <button data-target="image-model">Usa per Immagini</button>

--- a/ai_influencer/webapp/tests/test_openrouter.py
+++ b/ai_influencer/webapp/tests/test_openrouter.py
@@ -149,6 +149,8 @@ class HelperFunctionsTests(unittest.TestCase):
         self.assertEqual(summary[0]["id"], "model-a")
         self.assertEqual(summary[1]["id"], "model-b")
         self.assertIn("image", summary[1]["capabilities"])
+        self.assertIsNone(summary[0]["pricing_display"])
+        self.assertEqual(summary[1]["pricing_display"], "Image Prompt: $0.1")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -55,7 +55,10 @@ def test_list_models_returns_summarized_payload_and_closes_client():
         app.dependency_overrides.pop(get_client, None)
 
     assert response.status_code == 200
-    assert response.json() == {"models": summarize_models(stub_client.models)}
+    payload = response.json()
+    assert payload == {"models": summarize_models(stub_client.models)}
+    pricing_displays = [model["pricing_display"] for model in payload["models"]]
+    assert pricing_displays == ["Output: $0.001", "Video: $0.01"]
     assert stub_client.close_called is True
 
 


### PR DESCRIPTION
## Summary
- add logic to summarize OpenRouter pricing into a human-friendly `pricing_display`
- assert the new field in webapp and helper tests
- render pricing text in the model list UI with minor styling tweaks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6f13e56bc832082c8652503776a5e