### PR TITLE
Add filterable model selectors to generation forms

### DIFF
--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -205,6 +205,20 @@ textarea {
   font-size: 1rem;
 }
 
+.model-selector {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.model-selector select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(240, 246, 252, 0.2);
+  background: rgba(13, 17, 23, 0.7);
+  color: inherit;
+  font-size: 1rem;
+}
+
 textarea {
   resize: vertical;
   min-height: 120px;

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -48,7 +48,16 @@
           <h2>Generazione Testo</h2>
           <form id="text-form" class="form">
             <label>Modello
-              <input type="text" id="text-model" required placeholder="es. openrouter/auto" />
+              <div class="model-selector">
+                <input
+                  type="search"
+                  data-filter-for="text-model"
+                  placeholder="Filtra modelli testo"
+                />
+                <select id="text-model" data-capability="text" required>
+                  <option value="">Seleziona un modello</option>
+                </select>
+              </div>
             </label>
             <label>Prompt
               <textarea id="text-prompt" rows="4" required placeholder="Descrivi il contenuto da creare"></textarea>
@@ -62,7 +71,16 @@
           <h2>Generazione Immagine</h2>
           <form id="image-form" class="form">
             <label>Modello
-              <input type="text" id="image-model" required placeholder="es. stability-ai/stable-diffusion-xl-base-1.0" />
+              <div class="model-selector">
+                <input
+                  type="search"
+                  data-filter-for="image-model"
+                  placeholder="Filtra modelli immagine"
+                />
+                <select id="image-model" data-capability="image" required>
+                  <option value="">Seleziona un modello</option>
+                </select>
+              </div>
             </label>
             <label>Prompt
               <textarea id="image-prompt" rows="3" required placeholder="Descrivi l'immagine"></textarea>
@@ -87,7 +105,16 @@
           <h2>Generazione Video</h2>
           <form id="video-form" class="form">
             <label>Modello
-              <input type="text" id="video-model" required placeholder="es. openrouter/video-latest" />
+              <div class="model-selector">
+                <input
+                  type="search"
+                  data-filter-for="video-model"
+                  placeholder="Filtra modelli video"
+                />
+                <select id="video-model" data-capability="video" required>
+                  <option value="">Seleziona un modello</option>
+                </select>
+              </div>
             </label>
             <label>Prompt
               <textarea id="video-prompt" rows="3" required placeholder="Descrivi il video"></textarea>


### PR DESCRIPTION
## Summary
- replace free-text model fields with searchable select pickers in each generator form
- populate the new selects from the models cache, add filtering helpers, and wire model-card buttons to update the fields
- align the filter/search controls with the selects for a consistent layout

## Testing
- uvicorn ai_influencer.webapp.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68d760f278fc8320b4d2077040011d11