### PR TITLE
Add CRUD data storage and management interface

### DIFF
--- a/ai_influencer/webapp/static/data.js
+++ b/ai_influencer/webapp/static/data.js
@@ -1,0 +1,165 @@
+const API_ENDPOINT = "/api/data";
+const tableBody = document.querySelector("#data-table tbody");
+const statusBox = document.getElementById("data-status");
+const form = document.getElementById("data-form");
+const idInput = document.getElementById("record-id");
+const nameInput = document.getElementById("record-name");
+const valueInput = document.getElementById("record-value");
+const cancelEditButton = document.getElementById("cancel-edit");
+const saveButton = document.getElementById("save-record");
+
+function showStatus(message, isError = false) {
+  statusBox.textContent = message;
+  statusBox.classList.toggle("error", isError);
+  statusBox.classList.toggle("empty", !isError && !tableBody.children.length);
+}
+
+function resetForm() {
+  form.reset();
+  idInput.value = "";
+  cancelEditButton.hidden = true;
+  saveButton.textContent = "Salva record";
+  nameInput.focus();
+}
+
+function renderRecords(records) {
+  tableBody.innerHTML = "";
+  if (!records.length) {
+    showStatus("Nessun record presente.");
+    return;
+  }
+
+  records.forEach((record) => {
+    const row = document.createElement("tr");
+    row.dataset.id = record.id;
+
+    const idCell = document.createElement("td");
+    idCell.textContent = record.id;
+    row.appendChild(idCell);
+
+    const nameCell = document.createElement("td");
+    nameCell.textContent = record.name;
+    row.appendChild(nameCell);
+
+    const valueCell = document.createElement("td");
+    valueCell.textContent = record.value;
+    row.appendChild(valueCell);
+
+    const updatedCell = document.createElement("td");
+    updatedCell.textContent = new Date(record.updated_at).toLocaleString();
+    row.appendChild(updatedCell);
+
+    const actionsCell = document.createElement("td");
+    actionsCell.className = "actions";
+
+    const editButton = document.createElement("button");
+    editButton.type = "button";
+    editButton.textContent = "Modifica";
+    editButton.addEventListener("click", () => startEdit(record));
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "button-secondary";
+    deleteButton.textContent = "Elimina";
+    deleteButton.addEventListener("click", () => deleteRecord(record.id));
+
+    actionsCell.append(editButton, deleteButton);
+    row.appendChild(actionsCell);
+
+    tableBody.appendChild(row);
+  });
+
+  showStatus(`Record disponibili: ${records.length}`);
+}
+
+async function loadRecords() {
+  try {
+    const response = await fetch(API_ENDPOINT);
+    if (!response.ok) {
+      throw new Error(`Impossibile caricare i dati (${response.status})`);
+    }
+    const payload = await response.json();
+    renderRecords(payload.items ?? []);
+  } catch (error) {
+    console.error(error);
+    showStatus("Errore durante il caricamento dei dati", true);
+  }
+}
+
+function startEdit(record) {
+  idInput.value = record.id;
+  nameInput.value = record.name;
+  valueInput.value = record.value;
+  saveButton.textContent = "Aggiorna record";
+  cancelEditButton.hidden = false;
+  nameInput.focus();
+}
+
+async function submitData(event) {
+  event.preventDefault();
+  const payload = {
+    name: nameInput.value.trim(),
+    value: valueInput.value.trim(),
+  };
+
+  if (!payload.name || !payload.value) {
+    showStatus("Compila tutti i campi prima di salvare", true);
+    return;
+  }
+
+  const recordId = idInput.value ? Number(idInput.value) : null;
+  const method = recordId ? "PUT" : "POST";
+  const url = recordId ? `${API_ENDPOINT}/${recordId}` : API_ENDPOINT;
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      const message = detail.detail || "Errore durante il salvataggio";
+      throw new Error(message);
+    }
+
+    resetForm();
+    await loadRecords();
+    showStatus("Record salvato correttamente");
+  } catch (error) {
+    console.error(error);
+    showStatus(error.message, true);
+  }
+}
+
+async function deleteRecord(recordId) {
+  if (!Number.isInteger(recordId)) {
+    return;
+  }
+
+  try {
+    const response = await fetch(`${API_ENDPOINT}/${recordId}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) {
+      const detail = await response.json().catch(() => ({}));
+      const message = detail.detail || "Impossibile eliminare il record";
+      throw new Error(message);
+    }
+    await loadRecords();
+    showStatus("Record eliminato");
+  } catch (error) {
+    console.error(error);
+    showStatus(error.message, true);
+  }
+}
+
+cancelEditButton.addEventListener("click", () => {
+  resetForm();
+  showStatus("Modifica annullata");
+});
+
+form.addEventListener("submit", submitData);
+
+document.addEventListener("DOMContentLoaded", loadRecords);

--- a/ai_influencer/webapp/storage.py
+++ b/ai_influencer/webapp/storage.py
@@ -1,0 +1,106 @@
+"""Simple storage helpers for managing application data records."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS data_records (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+"""
+
+
+class StorageError(RuntimeError):
+    """Raised when the storage backend cannot be initialised."""
+
+
+def _get_db_path() -> Path:
+    raw_path = os.environ.get("DATA_DB_PATH")
+    if not raw_path:
+        raise StorageError("DATA_DB_PATH environment variable is not configured")
+    path = Path(raw_path).expanduser().resolve()
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def create_connection() -> sqlite3.Connection:
+    """Create and return an initialised SQLite connection."""
+
+    path = _get_db_path()
+    connection = sqlite3.connect(path, check_same_thread=False)
+    connection.row_factory = sqlite3.Row
+    _initialise_schema(connection)
+    return connection
+
+
+def _initialise_schema(connection: sqlite3.Connection) -> None:
+    with connection:
+        connection.executescript(SCHEMA)
+
+
+def list_records(connection: sqlite3.Connection) -> list[Dict[str, Any]]:
+    cursor = connection.execute(
+        "SELECT id, name, value, updated_at FROM data_records ORDER BY id ASC"
+    )
+    rows = cursor.fetchall()
+    return [dict(row) for row in rows]
+
+
+def _fetch_record(connection: sqlite3.Connection, record_id: int) -> Dict[str, Any]:
+    cursor = connection.execute(
+        "SELECT id, name, value, updated_at FROM data_records WHERE id = ?",
+        (record_id,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise KeyError(record_id)
+    return dict(row)
+
+
+def update_record(
+    connection: sqlite3.Connection,
+    *,
+    name: str,
+    value: str,
+    record_id: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Insert a new record or update an existing one."""
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    if record_id is None:
+        cursor = connection.execute(
+            "INSERT INTO data_records (name, value, updated_at) VALUES (?, ?, ?)",
+            (name, value, timestamp),
+        )
+        new_id = cursor.lastrowid
+        connection.commit()
+        return _fetch_record(connection, int(new_id))
+
+    cursor = connection.execute(
+        "UPDATE data_records SET name = ?, value = ?, updated_at = ? WHERE id = ?",
+        (name, value, timestamp, record_id),
+    )
+    if cursor.rowcount == 0:
+        connection.rollback()
+        raise KeyError(record_id)
+    connection.commit()
+    return _fetch_record(connection, record_id)
+
+
+def delete_record(connection: sqlite3.Connection, record_id: int) -> None:
+    cursor = connection.execute(
+        "DELETE FROM data_records WHERE id = ?",
+        (record_id,),
+    )
+    if cursor.rowcount == 0:
+        connection.rollback()
+        raise KeyError(record_id)
+    connection.commit()

--- a/ai_influencer/webapp/templates/data.html
+++ b/ai_influencer/webapp/templates/data.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestione dati - AI Influencer Control Hub</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="header-bar">
+        <h1>Archivio dati</h1>
+        <nav class="app-nav">
+          <a href="/"{% if active_nav == "home" %} aria-current="page"{% endif %}
+            >Generazione contenuti</a
+          >
+          <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
+            >Analisi influencer</a
+          >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Dati</a
+          >
+          <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
+            >Impostazioni</a
+          >
+        </nav>
+      </div>
+      <p>
+        Crea, aggiorna e rimuovi elementi dell'archivio applicativo. I dati vengono
+        salvati in un database SQLite locale definito dall'ambiente
+        <code>DATA_DB_PATH</code>.
+      </p>
+    </header>
+
+    <main class="layout">
+      <section class="card">
+        <h2>Nuovo record</h2>
+        <form id="data-form" class="form" autocomplete="off">
+          <input type="hidden" id="record-id" name="id" />
+          <label>
+            Nome
+            <input
+              type="text"
+              id="record-name"
+              name="name"
+              required
+              maxlength="255"
+              placeholder="es. Campagna"
+            />
+          </label>
+          <label>
+            Valore
+            <textarea
+              id="record-value"
+              name="value"
+              rows="3"
+              required
+              placeholder="Inserisci il contenuto associato"
+            ></textarea>
+          </label>
+          <div class="form-actions">
+            <button type="submit" id="save-record">Salva record</button>
+            <button type="button" id="cancel-edit" class="button-secondary" hidden>
+              Annulla modifica
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2>Record salvati</h2>
+        <div id="data-status" class="status-message empty" role="status">
+          Nessun record presente.
+        </div>
+        <div class="table-wrapper">
+          <table id="data-table">
+            <thead>
+              <tr>
+                <th scope="col">ID</th>
+                <th scope="col">Nome</th>
+                <th scope="col">Valore</th>
+                <th scope="col">Aggiornato</th>
+                <th scope="col" class="actions">Azioni</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script src="/static/data.js" type="module"></script>
+  </body>
+</html>

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/influencer.html
+++ b/ai_influencer/webapp/templates/influencer.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >


### PR DESCRIPTION
## Summary
- add a SQLite-backed storage helper that reads DATA_DB_PATH and offers CRUD primitives
- expose data management HTML and REST endpoints plus frontend assets for interaction
- cover the new data workflows with tests that exercise success and error scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d767767b388320a515bf5c3c571f8a