### PR TITLE
Add data management endpoints and UI

### DIFF
--- a/ai_influencer/webapp/static/data.js
+++ b/ai_influencer/webapp/static/data.js
@@ -1,0 +1,280 @@
+const listEl = document.getElementById('data-list');
+const emptyStateEl = document.getElementById('data-empty');
+const createForm = document.getElementById('data-form');
+const createStatus = document.getElementById('data-form-status');
+const editSection = document.querySelector('.data-editor');
+const editForm = document.getElementById('data-edit-form');
+const editStatus = document.getElementById('edit-status');
+const cancelEditBtn = document.getElementById('cancel-edit');
+
+let dataItems = [];
+let editingId = null;
+
+function setStatus(element, message, type = 'info') {
+  element.textContent = message;
+  element.classList.remove('empty', 'error', 'loading');
+  if (type === 'loading') {
+    element.classList.add('loading');
+  } else if (type === 'error') {
+    element.classList.add('error');
+  } else if (type === 'empty') {
+    element.classList.add('empty');
+  } else if (!message) {
+    element.classList.add('empty');
+  }
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatDate(value) {
+  if (!value) {
+    return 'n/d';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('it-IT', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+async function parseError(response) {
+  try {
+    const payload = await response.json();
+    if (typeof payload?.detail === 'string') {
+      return payload.detail;
+    }
+    if (payload?.detail?.message) {
+      return payload.detail.message;
+    }
+    if (Array.isArray(payload?.detail) && payload.detail.length > 0) {
+      const detail = payload.detail[0];
+      if (typeof detail?.msg === 'string') {
+        return detail.msg;
+      }
+    }
+    return response.statusText || 'Richiesta non riuscita';
+  } catch (error) {
+    return response.statusText || 'Richiesta non riuscita';
+  }
+}
+
+function renderList() {
+  if (!Array.isArray(dataItems) || dataItems.length === 0) {
+    listEl.hidden = true;
+    emptyStateEl.hidden = false;
+    setStatus(
+      emptyStateEl,
+      'Nessun dato disponibile. Aggiungi una nuova voce per iniziare.',
+      'empty',
+    );
+    return;
+  }
+
+  listEl.hidden = false;
+  emptyStateEl.hidden = true;
+
+  const fragments = dataItems.map((item) => {
+    const li = document.createElement('li');
+    li.dataset.id = String(item.id);
+
+    const header = document.createElement('div');
+    header.className = 'data-item-header';
+
+    const title = document.createElement('strong');
+    title.innerHTML = escapeHtml(item.name);
+    header.appendChild(title);
+
+    if (item.category) {
+      const tag = document.createElement('span');
+      tag.className = 'data-tag';
+      tag.innerHTML = escapeHtml(item.category);
+      header.appendChild(tag);
+    }
+
+    li.appendChild(header);
+
+    if (item.description) {
+      const description = document.createElement('p');
+      description.innerHTML = escapeHtml(item.description);
+      li.appendChild(description);
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'data-item-meta';
+    meta.innerHTML = `ID #${escapeHtml(String(item.id))} · Creato ${escapeHtml(
+      formatDate(item.created_at),
+    )} · Aggiornato ${escapeHtml(formatDate(item.updated_at))}`;
+    li.appendChild(meta);
+
+    const actions = document.createElement('div');
+    actions.className = 'data-item-actions';
+
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.textContent = 'Modifica';
+    editBtn.addEventListener('click', () => startEdit(item.id));
+    actions.appendChild(editBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.textContent = 'Elimina';
+    deleteBtn.addEventListener('click', () => deleteItem(item.id));
+    actions.appendChild(deleteBtn);
+
+    li.appendChild(actions);
+    return li;
+  });
+
+  listEl.replaceChildren(...fragments);
+}
+
+async function loadData() {
+  setStatus(createStatus, 'Caricamento dati…', 'loading');
+  try {
+    const response = await fetch('/api/data');
+    if (!response.ok) {
+      throw new Error(await parseError(response));
+    }
+    const payload = await response.json();
+    dataItems = Array.isArray(payload?.items) ? payload.items : [];
+    renderList();
+    setStatus(createStatus, 'Archivio aggiornato.');
+  } catch (error) {
+    setStatus(createStatus, `Errore durante il caricamento: ${error.message}`, 'error');
+    listEl.hidden = true;
+    emptyStateEl.hidden = false;
+    setStatus(emptyStateEl, 'Impossibile caricare i dati.', 'error');
+  }
+}
+
+function resetEdit() {
+  editingId = null;
+  editSection.hidden = true;
+  editForm.reset();
+  setStatus(editStatus, 'Seleziona una voce dall\'elenco per modificarla o rimuoverla.', 'info');
+}
+
+function startEdit(id) {
+  const item = dataItems.find((entry) => entry.id === id);
+  if (!item) {
+    return;
+  }
+  editingId = id;
+  editSection.hidden = false;
+  editForm.querySelector('#edit-id').value = String(item.id);
+  editForm.querySelector('#edit-name').value = item.name ?? '';
+  editForm.querySelector('#edit-category').value = item.category ?? '';
+  editForm.querySelector('#edit-description').value = item.description ?? '';
+  setStatus(editStatus, 'Modifica i campi e salva le modifiche.');
+}
+
+async function deleteItem(id) {
+  setStatus(editStatus, 'Rimozione in corso…', 'loading');
+  try {
+    const response = await fetch(`/api/data/${id}`, { method: 'DELETE' });
+    if (!response.ok) {
+      throw new Error(await parseError(response));
+    }
+    if (editingId === id) {
+      resetEdit();
+    }
+    await loadData();
+    setStatus(editStatus, 'Voce eliminata.');
+  } catch (error) {
+    setStatus(editStatus, `Errore: ${error.message}`, 'error');
+  }
+}
+
+createForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const formData = new FormData(createForm);
+  const payload = {
+    name: String(formData.get('name') || '').trim(),
+    category: String(formData.get('category') || '').trim() || null,
+    description: String(formData.get('description') || '').trim() || null,
+  };
+
+  if (!payload.name) {
+    setStatus(createStatus, 'Il nome è obbligatorio.', 'error');
+    return;
+  }
+
+  setStatus(createStatus, 'Salvataggio in corso…', 'loading');
+  try {
+    const response = await fetch('/api/data', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      throw new Error(await parseError(response));
+    }
+    createForm.reset();
+    setStatus(createStatus, 'Voce salvata con successo.');
+    await loadData();
+  } catch (error) {
+    setStatus(createStatus, `Errore: ${error.message}`, 'error');
+  }
+});
+
+editForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  if (!editingId) {
+    setStatus(editStatus, 'Nessuna voce selezionata.', 'error');
+    return;
+  }
+  const formData = new FormData(editForm);
+  const payload = {
+    name: String(formData.get('name') || '').trim() || undefined,
+    category: String(formData.get('category') || '').trim(),
+    description: String(formData.get('description') || '').trim(),
+  };
+
+  if (!payload.name) {
+    setStatus(editStatus, 'Il nome è obbligatorio.', 'error');
+    return;
+  }
+
+  if (!payload.category) {
+    payload.category = null;
+  }
+  if (!payload.description) {
+    payload.description = null;
+  }
+
+  setStatus(editStatus, 'Aggiornamento in corso…', 'loading');
+  try {
+    const response = await fetch(`/api/data/${editingId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      throw new Error(await parseError(response));
+    }
+    setStatus(editStatus, 'Voce aggiornata.');
+    await loadData();
+  } catch (error) {
+    setStatus(editStatus, `Errore: ${error.message}`, 'error');
+  }
+});
+
+cancelEditBtn.addEventListener('click', () => {
+  resetEdit();
+});
+
+loadData().finally(() => {
+  if (dataItems.length === 0) {
+    resetEdit();
+  }
+});

--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -465,6 +465,122 @@ textarea {
   color: #ff7b72;
 }
 
+.data-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  padding: 2rem;
+}
+
+.data-summary {
+  grid-column: span 2;
+}
+
+.data-form-card {
+  grid-column: span 1;
+}
+
+.data-editor {
+  grid-column: span 1;
+}
+
+.data-list {
+  list-style: none;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.data-list li {
+  background: rgba(13, 17, 23, 0.65);
+  border-radius: 12px;
+  border: 1px solid rgba(240, 246, 252, 0.08);
+  padding: 0.9rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.data-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.data-item-header strong {
+  font-size: 1rem;
+}
+
+.data-item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: rgba(240, 246, 252, 0.65);
+}
+
+.data-item-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.data-item-actions button {
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(240, 246, 252, 0.35);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+.data-item-actions button:hover,
+.data-item-actions button:focus-visible {
+  background: rgba(240, 246, 252, 0.12);
+  border-color: rgba(240, 246, 252, 0.5);
+  outline: none;
+}
+
+.data-tag {
+  background: rgba(88, 166, 255, 0.18);
+  color: #58a6ff;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+button.secondary {
+  background: transparent;
+  color: inherit;
+  border: 1px solid rgba(240, 246, 252, 0.35);
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+}
+
+button.secondary:hover,
+button.secondary:focus-visible {
+  background: rgba(240, 246, 252, 0.12);
+  border-color: rgba(240, 246, 252, 0.5);
+  outline: none;
+}
+
+.muted {
+  color: rgba(240, 246, 252, 0.7);
+}
+
 .settings-layout {
   max-width: 720px;
   margin: 0 auto;
@@ -539,5 +655,11 @@ textarea {
 
   .generators {
     order: 1;
+  }
+
+  .data-summary,
+  .data-form-card,
+  .data-editor {
+    grid-column: span 1;
   }
 }

--- a/ai_influencer/webapp/storage.py
+++ b/ai_influencer/webapp/storage.py
@@ -1,0 +1,95 @@
+"""In-memory storage for demo data management endpoints."""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+
+class DataStorage:
+    """Thread-safe in-memory storage used by the data management API."""
+
+    def __init__(self) -> None:
+        self._items: Dict[int, Dict[str, Any]] = {}
+        self._lock = Lock()
+        self._next_id = 1
+
+    def list(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [deepcopy(item) for item in self._items.values()]
+
+    def create(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        with self._lock:
+            item_id = self._next_id
+            self._next_id += 1
+            now = datetime.now(timezone.utc).isoformat()
+            item = {
+                "id": item_id,
+                "name": payload.get("name"),
+                "category": payload.get("category"),
+                "description": payload.get("description"),
+                "created_at": now,
+                "updated_at": now,
+            }
+            self._items[item_id] = item
+            return deepcopy(item)
+
+    def get(self, data_id: int) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            item = self._items.get(data_id)
+            return deepcopy(item) if item is not None else None
+
+    def update(self, data_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        with self._lock:
+            if data_id not in self._items:
+                raise KeyError(data_id)
+            now = datetime.now(timezone.utc).isoformat()
+            stored = deepcopy(self._items[data_id])
+            for key in ("name", "category", "description"):
+                if key in payload:
+                    stored[key] = payload[key]
+            stored["updated_at"] = now
+            self._items[data_id] = stored
+            return deepcopy(stored)
+
+    def delete(self, data_id: int) -> bool:
+        with self._lock:
+            if data_id not in self._items:
+                return False
+            del self._items[data_id]
+            return True
+
+    def clear(self) -> None:
+        with self._lock:
+            self._items.clear()
+            self._next_id = 1
+
+
+_STORAGE = DataStorage()
+
+
+def get_storage() -> DataStorage:
+    """FastAPI dependency returning the shared storage instance."""
+
+    return _STORAGE
+
+
+def list_data(storage: DataStorage) -> List[Dict[str, Any]]:
+    return storage.list()
+
+
+def create_data(storage: DataStorage, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return storage.create(payload)
+
+
+def get_data(storage: DataStorage, data_id: int) -> Optional[Dict[str, Any]]:
+    return storage.get(data_id)
+
+
+def update_data(storage: DataStorage, data_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return storage.update(data_id, payload)
+
+
+def delete_data(storage: DataStorage, data_id: int) -> bool:
+    return storage.delete(data_id)

--- a/ai_influencer/webapp/templates/data.html
+++ b/ai_influencer/webapp/templates/data.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestione dati - AI Control Hub</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="header-bar">
+        <h1>Gestione dati operativi</h1>
+        <nav class="app-nav">
+          <a href="/"{% if active_nav == "home" %} aria-current="page"{% endif %}
+            >Generazione contenuti</a
+          >
+          <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
+            >Analisi influencer</a
+          >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
+          <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
+            >Impostazioni</a
+          >
+        </nav>
+      </div>
+      <p>
+        Centralizza note operative, categorie di contenuto e insight raccolti durante le
+        campagne. Utilizza l'archivio per condividere dati di lavoro con il resto del team.
+      </p>
+    </header>
+
+    <main class="data-layout">
+      <section class="card data-summary">
+        <h2>Archivio</h2>
+        <p class="muted">
+          Raccogli e mantieni aggiornate le informazioni critiche per la gestione delle
+          campagne e dei flussi creativi.
+        </p>
+        <div id="data-empty" class="status-message empty">
+          Nessun dato disponibile. Aggiungi una nuova voce per iniziare.
+        </div>
+        <ul id="data-list" class="data-list" hidden></ul>
+      </section>
+
+      <section class="card data-form-card">
+        <h2>Nuova voce</h2>
+        <form id="data-form" class="form" autocomplete="off">
+          <label>
+            Nome
+            <input type="text" id="data-name" name="name" required maxlength="200" />
+          </label>
+          <label>
+            Categoria
+            <input
+              type="text"
+              id="data-category"
+              name="category"
+              maxlength="100"
+              placeholder="es. Campagna, Analisi, Insight"
+            />
+          </label>
+          <label>
+            Descrizione
+            <textarea
+              id="data-description"
+              name="description"
+              rows="4"
+              maxlength="1000"
+              placeholder="Note operative o riferimenti"
+            ></textarea>
+          </label>
+          <button type="submit">Salva dato</button>
+        </form>
+        <div id="data-form-status" class="status-message empty">
+          Compila il form per creare una nuova voce nell'archivio.
+        </div>
+      </section>
+
+      <section class="card data-editor" hidden>
+        <h2>Modifica voce</h2>
+        <form id="data-edit-form" class="form" autocomplete="off">
+          <input type="hidden" id="edit-id" />
+          <label>
+            Nome
+            <input type="text" id="edit-name" name="name" required maxlength="200" />
+          </label>
+          <label>
+            Categoria
+            <input type="text" id="edit-category" name="category" maxlength="100" />
+          </label>
+          <label>
+            Descrizione
+            <textarea id="edit-description" name="description" rows="4" maxlength="1000"></textarea>
+          </label>
+          <div class="button-row">
+            <button type="submit">Aggiorna</button>
+            <button type="button" id="cancel-edit" class="secondary">Annulla</button>
+          </div>
+        </form>
+        <div id="edit-status" class="status-message empty">
+          Seleziona una voce dall'elenco per modificarla o rimuoverla.
+        </div>
+      </section>
+    </main>
+
+    <script src="/static/data.js" type="module"></script>
+  </body>
+</html>

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/influencer.html
+++ b/ai_influencer/webapp/templates/influencer.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/tests/test_data_endpoints.py
+++ b/tests/test_data_endpoints.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ai_influencer.webapp.main import app
+from ai_influencer.webapp.storage import get_storage
+
+
+@pytest.fixture(autouse=True)
+def clear_storage():
+    storage = get_storage()
+    storage.clear()
+    yield
+    storage.clear()
+
+
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def create_sample(client: TestClient, payload: Dict[str, Any]) -> Dict[str, Any]:
+    response = client.post("/api/data", json=payload)
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_list_initially_empty():
+    response = client().get("/api/data")
+    assert response.status_code == 200
+    assert response.json() == {"items": []}
+
+
+def test_create_and_retrieve_item():
+    payload = {
+        "name": "Briefing campagna",
+        "category": "Campagna",
+        "description": "Documentazione iniziale",
+    }
+    item = create_sample(client(), payload)
+
+    assert item["id"] == 1
+    assert item["name"] == payload["name"]
+    assert item["category"] == payload["category"]
+    assert item["description"] == payload["description"]
+    assert "created_at" in item
+    assert "updated_at" in item
+
+    response = client().get(f"/api/data/{item['id']}")
+    assert response.status_code == 200
+    fetched = response.json()
+    assert fetched == item
+
+
+def test_list_returns_created_items():
+    c = client()
+    first = create_sample(
+        c,
+        {"name": "Studio target", "category": "Analisi", "description": "Persona"},
+    )
+    second = create_sample(
+        c,
+        {"name": "Script video", "category": "Contenuti", "description": "Storyboard"},
+    )
+
+    response = c.get("/api/data")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 2
+    assert data["items"][0]["id"] == first["id"]
+    assert data["items"][1]["id"] == second["id"]
+
+
+def test_update_item_and_clear_optional_fields():
+    c = client()
+    item = create_sample(
+        c,
+        {
+            "name": "Report mensile",
+            "category": "Report",
+            "description": "Sintesi iniziale",
+        },
+    )
+
+    response = c.put(
+        f"/api/data/{item['id']}",
+        json={"name": "Report mensile aggiornato", "category": "", "description": ""},
+    )
+    assert response.status_code == 200
+    updated = response.json()
+    assert updated["id"] == item["id"]
+    assert updated["name"] == "Report mensile aggiornato"
+    assert updated["category"] is None
+    assert updated["description"] is None
+    assert updated["updated_at"] != item["updated_at"]
+
+
+def test_delete_item():
+    c = client()
+    item = create_sample(c, {"name": "Bozza post", "category": "", "description": ""})
+
+    response = c.delete(f"/api/data/{item['id']}")
+    assert response.status_code == 200
+    assert response.json() == {"deleted": True}
+
+    not_found = c.get(f"/api/data/{item['id']}")
+    assert not_found.status_code == 404
+
+
+def test_get_missing_item_returns_404():
+    response = client().get("/api/data/999")
+    assert response.status_code == 404
+
+
+def test_update_missing_item_returns_404():
+    response = client().put("/api/data/999", json={"name": "Inesistente"})
+    assert response.status_code == 404
+
+
+def test_delete_missing_item_returns_404():
+    response = client().delete("/api/data/999")
+    assert response.status_code == 404
+
+
+def test_update_without_payload_returns_validation_error():
+    response = client().put("/api/data/1", json={})
+    assert response.status_code == 422
+
+
+def test_create_requires_valid_name():
+    response = client().post("/api/data", json={"name": "   "})
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add an in-memory storage layer with CRUD helpers and expose it via FastAPI dependencies
- build a Gestione dati page with supporting styles and client-side logic to manage records
- extend automated coverage with API tests for the new data endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d76acbda548320afd1d373eb2a441e