### PR TITLE
Handle no-op updates when editing records

### DIFF
--- a/ai_influencer/webapp/storage.py
+++ b/ai_influencer/webapp/storage.py
@@ -89,8 +89,13 @@ def update_record(
         (name, value, timestamp, record_id),
     )
     if cursor.rowcount == 0:
-        connection.rollback()
-        raise KeyError(record_id)
+        try:
+            _fetch_record(connection, record_id)
+        except KeyError:
+            connection.rollback()
+            raise
+        connection.commit()
+        return _fetch_record(connection, record_id)
     connection.commit()
     return _fetch_record(connection, record_id)
 


### PR DESCRIPTION
## Summary
- verify data record existence with a fresh lookup when an UPDATE reports zero affected rows
- keep raising KeyError for missing records while allowing no-op updates to succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d76d1471d8832097696d497e118499