### PR TITLE
Add data management page with interactive controls

### DIFF
--- a/ai_influencer/webapp/main.py
+++ b/ai_influencer/webapp/main.py
@@ -124,6 +124,13 @@ async def settings_view(request: Request) -> HTMLResponse:
     )
 
 
+@app.get("/data", response_class=HTMLResponse)
+async def data_view(request: Request) -> HTMLResponse:
+    return TEMPLATES.TemplateResponse(
+        "data.html", {"request": request, "active_nav": "data"}
+    )
+
+
 @app.get("/api/models")
 async def list_models(client: OpenRouterClient = Depends(get_client)) -> JSONResponse:
     try:

--- a/ai_influencer/webapp/static/data.js
+++ b/ai_influencer/webapp/static/data.js
@@ -1,0 +1,396 @@
+const statusMessage = document.querySelector('#data-status');
+const tableBody = document.querySelector('#data-table tbody');
+const createButton = document.querySelector('#create-data');
+const modal = document.querySelector('#data-modal');
+const modalTitle = document.querySelector('#data-modal-title');
+const modalSubtitle = document.querySelector('#data-modal-subtitle');
+const modalDetails = document.querySelector('#data-details');
+const form = document.querySelector('#data-form');
+const payloadField = document.querySelector('#data-payload');
+const saveButton = document.querySelector('#data-save');
+const closeButton = document.querySelector('#data-close');
+const formError = document.querySelector('#data-form-error');
+
+let entries = [];
+let currentEntry = null;
+let currentMode = 'view';
+
+function setStatus({ message, tone }) {
+  if (!statusMessage) return;
+  statusMessage.hidden = false;
+  statusMessage.textContent = message;
+  statusMessage.classList.remove('error', 'loading', 'empty');
+  if (tone) {
+    statusMessage.classList.add(tone);
+  }
+}
+
+function hideStatus() {
+  if (!statusMessage) return;
+  statusMessage.hidden = true;
+  statusMessage.classList.remove('error', 'loading', 'empty');
+}
+
+function pickField(entry, keys, fallback = '') {
+  if (!entry || typeof entry !== 'object') {
+    return fallback;
+  }
+  for (const key of keys) {
+    if (entry[key] !== undefined && entry[key] !== null && `${entry[key]}`.trim() !== '') {
+      return entry[key];
+    }
+  }
+  return fallback;
+}
+
+function formatDateValue(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return `${value}`;
+  }
+  return date.toLocaleString('it-IT', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function renderTable(data) {
+  tableBody.innerHTML = '';
+
+  if (!data.length) {
+    setStatus({ message: 'Nessun dato disponibile. Crea un nuovo record per iniziare.', tone: 'empty' });
+    return;
+  }
+
+  hideStatus();
+
+  data.forEach((entry) => {
+    const row = document.createElement('tr');
+    const entryId = getEntryId(entry);
+    if (entryId) {
+      row.dataset.id = entryId;
+    }
+    const canMutate = Boolean(entryId);
+
+    const nameCell = document.createElement('td');
+    nameCell.textContent = pickField(entry, ['name', 'title', 'label', 'display_name', 'id'], '—');
+    row.appendChild(nameCell);
+
+    const categoryCell = document.createElement('td');
+    categoryCell.textContent = pickField(entry, ['category', 'type', 'segment', 'status'], '—');
+    row.appendChild(categoryCell);
+
+    const updatedCell = document.createElement('td');
+    const updatedValue = pickField(entry, ['updated_at', 'updated', 'modified_at', 'created_at', 'timestamp']);
+    updatedCell.textContent = formatDateValue(updatedValue) || '—';
+    row.appendChild(updatedCell);
+
+    const actionsCell = document.createElement('td');
+    const actionsWrapper = document.createElement('div');
+    actionsWrapper.className = 'model-actions';
+
+    actionsWrapper.appendChild(createActionButton('Visualizza', 'view'));
+    actionsWrapper.appendChild(
+      createActionButton('Modifica', 'edit', '', { disabled: !canMutate })
+    );
+    actionsWrapper.appendChild(
+      createActionButton('Elimina', 'delete', 'button-secondary', { disabled: !canMutate })
+    );
+
+    actionsCell.appendChild(actionsWrapper);
+    row.appendChild(actionsCell);
+
+    tableBody.appendChild(row);
+  });
+}
+
+function createActionButton(label, action, extraClass = '', options = {}) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = label;
+  button.dataset.action = action;
+  if (extraClass) {
+    button.classList.add(extraClass);
+  }
+  if (options.disabled) {
+    button.disabled = true;
+    button.title = 'Operazione non disponibile per questo record';
+  }
+  return button;
+}
+
+function getEntryId(entry) {
+  const value = pickField(entry, ['id', 'uuid', 'slug']);
+  return value ? `${value}` : '';
+}
+
+async function fetchData() {
+  setStatus({ message: 'Caricamento dati...', tone: 'loading' });
+  try {
+    const response = await fetch('/api/data');
+    if (!response.ok) {
+      throw new Error('Impossibile recuperare i dati');
+    }
+    const payload = await response.json().catch(() => ({}));
+    const data = Array.isArray(payload) ? payload : payload.data || [];
+    entries = Array.isArray(data) ? data : [];
+    renderTable(entries);
+  } catch (error) {
+    tableBody.innerHTML = '';
+    setStatus({ message: error.message || 'Errore inatteso', tone: 'error' });
+  }
+}
+
+function cloneEntry(entry) {
+  if (entry === null || entry === undefined) return null;
+  if (typeof entry !== 'object') return entry;
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(entry);
+    } catch (error) {
+      // Ignore and fallback to JSON clone
+    }
+  }
+  try {
+    return JSON.parse(JSON.stringify(entry));
+  } catch (error) {
+    return { ...entry };
+  }
+}
+
+function openModal(mode, entry = null) {
+  currentMode = mode;
+  currentEntry = entry ? cloneEntry(entry) : null;
+  formError.classList.add('hidden');
+  formError.textContent = '';
+
+  if (mode === 'view') {
+    modalTitle.textContent = 'Dettaglio record';
+    modalSubtitle.textContent = currentEntry ? describeEntry(currentEntry) : '';
+    renderDetails(currentEntry);
+    form.classList.add('hidden');
+    saveButton.classList.add('hidden');
+  } else if (mode === 'edit') {
+    modalTitle.textContent = 'Modifica record';
+    modalSubtitle.textContent = currentEntry ? describeEntry(currentEntry) : '';
+    renderDetails(null);
+    form.classList.remove('hidden');
+    payloadField.value = JSON.stringify(currentEntry ?? {}, null, 2);
+    payloadField.focus();
+    saveButton.textContent = 'Salva modifiche';
+    saveButton.classList.remove('hidden');
+  } else {
+    modalTitle.textContent = 'Nuovo record';
+    modalSubtitle.textContent = 'Compila il payload JSON per creare un nuovo elemento.';
+    renderDetails(null);
+    form.classList.remove('hidden');
+    payloadField.value = JSON.stringify({ name: '', category: '', payload: {} }, null, 2);
+    payloadField.focus();
+    saveButton.textContent = 'Crea record';
+    saveButton.classList.remove('hidden');
+  }
+
+  toggleDialog(true);
+}
+
+function describeEntry(entry) {
+  if (!entry) return '';
+  if (typeof entry !== 'object') {
+    return formatDetailValue(entry);
+  }
+  const name = pickField(entry, ['name', 'title', 'label', 'display_name', 'id'], 'Record');
+  const category = pickField(entry, ['category', 'type', 'segment', 'status']);
+  if (category) {
+    return `${name} · ${category}`;
+  }
+  return `${name}`;
+}
+
+function renderDetails(entry) {
+  modalDetails.innerHTML = '';
+  if (entry === null || entry === undefined) {
+    modalDetails.classList.add('hidden');
+    modalDetails.setAttribute('aria-hidden', 'true');
+    return;
+  }
+  modalDetails.classList.remove('hidden');
+  modalDetails.setAttribute('aria-hidden', 'false');
+  if (typeof entry !== 'object') {
+    const row = document.createElement('div');
+    row.className = 'data-detail-row';
+
+    const keyElement = document.createElement('span');
+    keyElement.className = 'data-detail-key';
+    keyElement.textContent = 'valore';
+
+    const valueElement = document.createElement('span');
+    valueElement.className = 'data-detail-value';
+    valueElement.textContent = formatDetailValue(entry);
+
+    row.append(keyElement, valueElement);
+    modalDetails.appendChild(row);
+    return;
+  }
+
+  const entriesList = Object.entries(entry);
+  if (!entriesList.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = 'Nessun dettaglio disponibile per questo record.';
+    modalDetails.appendChild(empty);
+    return;
+  }
+
+  entriesList.forEach(([key, value]) => {
+    const row = document.createElement('div');
+    row.className = 'data-detail-row';
+
+    const keyElement = document.createElement('span');
+    keyElement.className = 'data-detail-key';
+    keyElement.textContent = key;
+
+    const valueElement = document.createElement('span');
+    valueElement.className = 'data-detail-value';
+    valueElement.textContent = formatDetailValue(value);
+
+    row.append(keyElement, valueElement);
+    modalDetails.appendChild(row);
+  });
+}
+
+function formatDetailValue(value) {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch (error) {
+      return '[Oggetto]';
+    }
+  }
+  return `${value}`;
+}
+
+function toggleDialog(shouldOpen) {
+  if (!modal) return;
+  if (shouldOpen) {
+    if (typeof modal.showModal === 'function') {
+      modal.showModal();
+    } else {
+      modal.setAttribute('open', '');
+    }
+  } else {
+    if (typeof modal.close === 'function') {
+      modal.close();
+    }
+    modal.removeAttribute('open');
+  }
+}
+
+function closeModal() {
+  toggleDialog(false);
+  currentEntry = null;
+  currentMode = 'view';
+  formError.classList.add('hidden');
+  formError.textContent = '';
+  modalSubtitle.textContent = '';
+  payloadField.value = '';
+  renderDetails(null);
+}
+
+async function handleSave() {
+  formError.classList.add('hidden');
+  formError.textContent = '';
+  let payload;
+  try {
+    payload = JSON.parse(payloadField.value || '{}');
+  } catch (error) {
+    formError.textContent = 'Payload JSON non valido.';
+    formError.classList.remove('hidden');
+    return;
+  }
+
+  try {
+    if (currentMode === 'edit') {
+      const entryId = getEntryId(currentEntry || {});
+      if (!entryId) {
+        throw new Error('ID del record non disponibile.');
+      }
+      await mutate(`/api/data/${encodeURIComponent(entryId)}`, 'PUT', payload);
+    } else {
+      await mutate('/api/data', 'POST', payload);
+    }
+    closeModal();
+    await fetchData();
+  } catch (error) {
+    formError.textContent = error.message || 'Impossibile salvare il record.';
+    formError.classList.remove('hidden');
+  }
+}
+
+async function mutate(url, method, body) {
+  const config = { method };
+  const upperMethod = (method || '').toUpperCase();
+  if (upperMethod === 'POST' || upperMethod === 'PUT' || upperMethod === 'PATCH') {
+    config.headers = { 'Content-Type': 'application/json' };
+    config.body = JSON.stringify(body ?? {});
+  } else if (body !== undefined) {
+    config.headers = { 'Content-Type': 'application/json' };
+    config.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, config);
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({}));
+    const detail = payload?.detail || payload?.message;
+    throw new Error(detail || 'Richiesta non riuscita.');
+  }
+  return response.json().catch(() => ({}));
+}
+
+async function handleTableClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) return;
+  const row = button.closest('tr');
+  if (!row) return;
+  const entryId = row.dataset.id;
+  const entry = entries.find((item) => getEntryId(item) === entryId) || null;
+  const action = button.dataset.action;
+
+  if (action === 'view') {
+    openModal('view', entry);
+  } else if (action === 'edit') {
+    openModal('edit', entry);
+  } else if (action === 'delete' && entryId) {
+    const confirmed = window.confirm('Eliminare definitivamente questo record?');
+    if (!confirmed) return;
+    try {
+      await mutate(`/api/data/${encodeURIComponent(entryId)}`, 'DELETE');
+      await fetchData();
+    } catch (error) {
+      setStatus({ message: error.message || 'Impossibile eliminare il record.', tone: 'error' });
+    }
+  }
+}
+
+function registerEvents() {
+  createButton?.addEventListener('click', () => openModal('create'));
+  tableBody?.addEventListener('click', handleTableClick);
+  saveButton?.addEventListener('click', handleSave);
+  closeButton?.addEventListener('click', closeModal);
+  if (modal) {
+    modal.addEventListener('cancel', (event) => {
+      event.preventDefault();
+      closeModal();
+    });
+    modal.addEventListener('close', () => {
+      currentEntry = null;
+      currentMode = 'view';
+    });
+  }
+}
+
+registerEvents();
+fetchData();

--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -12,6 +12,10 @@ body {
   min-height: 100vh;
 }
 
+.hidden {
+  display: none !important;
+}
+
 .app-header {
   padding: 2rem;
   text-align: center;
@@ -153,7 +157,8 @@ body {
 }
 
 .model-actions button,
-button[type='submit'] {
+button[type='submit'],
+.button-primary {
   background: #238636;
   color: #fff;
   border: none;
@@ -165,7 +170,8 @@ button[type='submit'] {
 }
 
 .model-actions button:hover,
-button[type='submit']:hover {
+button[type='submit']:hover,
+.button-primary:hover {
   transform: translateY(-1px);
   background: #2ea043;
 }
@@ -324,6 +330,189 @@ textarea {
   color: #ff7b72;
   border-color: rgba(255, 123, 114, 0.4);
   background: rgba(255, 123, 114, 0.1);
+}
+
+.data-layout {
+  padding: 2rem;
+  display: grid;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.data-card {
+  gap: 1.5rem;
+}
+
+.data-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.data-card-heading {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.data-subtitle {
+  margin: 0;
+  color: rgba(240, 246, 252, 0.7);
+}
+
+.data-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(35, 134, 54, 0.2);
+  border: 1px solid rgba(46, 160, 67, 0.4);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.table-container {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(240, 246, 252, 0.08);
+  background: rgba(13, 17, 23, 0.6);
+}
+
+.data-table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+}
+
+.data-table caption {
+  text-align: left;
+  padding: 1rem 1.25rem 0;
+  font-weight: 600;
+  color: rgba(240, 246, 252, 0.8);
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.85rem 1.25rem;
+  border-bottom: 1px solid rgba(240, 246, 252, 0.08);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table tbody tr:hover {
+  background: rgba(240, 246, 252, 0.06);
+}
+
+.data-table .model-actions {
+  justify-content: flex-start;
+}
+
+.data-table .model-actions button {
+  white-space: nowrap;
+}
+
+.data-modal {
+  border: none;
+  border-radius: 18px;
+  padding: 0;
+  width: min(640px, 92vw);
+  color: inherit;
+  background: transparent;
+}
+
+.data-modal::backdrop {
+  background: rgba(13, 17, 23, 0.75);
+  backdrop-filter: blur(6px);
+}
+
+.modal-surface {
+  background: rgba(22, 27, 34, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(240, 246, 252, 0.08);
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.data-modal-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.data-modal-subtitle {
+  margin: 0;
+  color: rgba(240, 246, 252, 0.68);
+}
+
+.data-details {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.data-detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 1rem;
+  background: rgba(13, 17, 23, 0.6);
+  border-radius: 12px;
+  padding: 0.65rem 0.85rem;
+}
+
+.data-detail-key {
+  font-weight: 600;
+  color: rgba(240, 246, 252, 0.75);
+  flex: 0 0 35%;
+}
+
+.data-detail-value {
+  flex: 1 1 auto;
+  text-align: left;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.data-form {
+  margin: 0;
+}
+
+.data-form textarea {
+  min-height: 180px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.modal-actions-right {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.data-modal[open] {
+  display: block;
+}
+
+@media (max-width: 720px) {
+  .data-card-header {
+    align-items: stretch;
+  }
+
+  .data-table {
+    min-width: 480px;
+  }
 }
 
 .influencer-block {

--- a/ai_influencer/webapp/templates/data.html
+++ b/ai_influencer/webapp/templates/data.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestione Dati - AI Influencer Control Hub</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="header-bar">
+        <h1>Gestione dei Dati Operativi</h1>
+        <nav class="app-nav">
+          <a href="/"{% if active_nav == "home" %} aria-current="page"{% endif %}>
+            Generazione contenuti</a
+          >
+          <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}>
+            Analisi influencer</a
+          >
+          <a href="/data"{% if active_nav == "data" %} aria-current="page"{% endif %}>
+            Gestione dati</a
+          >
+          <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}>
+            Impostazioni</a
+          >
+        </nav>
+      </div>
+      <p>
+        Monitora e modifica i record raccolti lungo la pipeline di analisi. Utilizza la
+        tabella dei <strong>[DATI]</strong> per visualizzare, aggiornare o eliminare le
+        voci archiviate.
+      </p>
+    </header>
+
+    <main class="data-layout">
+      <section class="card data-card">
+        <div class="data-card-header">
+          <div class="data-card-heading">
+            <span class="data-badge">[DATI]</span>
+            <h2>Archivio centrale</h2>
+            <p class="data-subtitle">
+              Snapshot delle entità sincronizzate con le API interne.
+            </p>
+          </div>
+          <button type="button" id="create-data" class="button-primary">Nuovo record</button>
+        </div>
+
+        <div id="data-status" class="status-message empty">
+          Nessun dato disponibile. Crea un nuovo record per iniziare.
+        </div>
+
+        <div class="table-container" aria-live="polite">
+          <table id="data-table" class="data-table">
+            <caption class="table-caption">Tabella dei [DATI]</caption>
+            <thead>
+              <tr>
+                <th scope="col">Nome</th>
+                <th scope="col">Categoria</th>
+                <th scope="col">Aggiornato</th>
+                <th scope="col">Azioni</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <dialog
+      id="data-modal"
+      class="data-modal"
+      aria-modal="true"
+      aria-labelledby="data-modal-title"
+    >
+      <div class="modal-surface">
+        <header class="data-modal-header">
+          <h2 id="data-modal-title">Dettaglio record</h2>
+          <p id="data-modal-subtitle" class="data-modal-subtitle"></p>
+        </header>
+        <section id="data-details" class="data-details"></section>
+        <form id="data-form" class="form data-form" autocomplete="off">
+          <label for="data-payload" class="data-payload-label">
+            Payload JSON
+            <textarea id="data-payload" name="payload" spellcheck="false"></textarea>
+          </label>
+          <div id="data-form-error" class="error hidden" role="alert"></div>
+        </form>
+        <footer class="modal-actions">
+          <div class="modal-actions-left">
+            <button type="button" id="data-close" class="button-secondary">Chiudi</button>
+          </div>
+          <div class="modal-actions-right">
+            <button type="button" id="data-save">Salva modifiche</button>
+          </div>
+        </footer>
+      </div>
+    </dialog>
+
+    <script src="/static/data.js" type="module"></script>
+  </body>
+</html>

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/data"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/influencer.html
+++ b/ai_influencer/webapp/templates/influencer.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/data"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/data"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >


### PR DESCRIPTION
## Summary
- add a dedicated data management template with navigation entry and modal scaffold
- implement the front-end module that fetches data, drives the table UI, and handles CRUD requests
- extend shared styles to cover the new table, modal, and button treatments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d76ad0f3408320a751b14cbbc2e378