### PR TITLE
Add data link to navigation bar

### DIFF
--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -41,6 +41,7 @@ body {
 
 .app-nav {
   display: inline-flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
 }

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/influencer.html
+++ b/ai_influencer/webapp/templates/influencer.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >


### PR DESCRIPTION
## Summary
- add the Gestione dati link to the navigation bar of every page with active state handling
- allow the navigation bar to wrap so the new link displays correctly on smaller screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d76ad52fd48320bf497c26e03effb2