### PR TITLE
Add REST data management endpoints with storage backend

### DIFF
--- a/ai_influencer/webapp/storage.py
+++ b/ai_influencer/webapp/storage.py
@@ -1,0 +1,83 @@
+"""Simple in-memory storage utilities for the demo REST API."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class _StorageState:
+    """Internal state container guarded by a lock."""
+
+    items: Dict[int, Dict[str, Any]] = field(default_factory=dict)
+    next_id: int = 1
+
+
+class DataStorage:
+    """Thread-safe in-memory storage for JSON-like payloads."""
+
+    def __init__(self) -> None:
+        self._state = _StorageState()
+        self._lock = Lock()
+
+    def list(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [item.copy() for item in self._state.items.values()]
+
+    def get(self, item_id: int) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            item = self._state.items.get(item_id)
+            return item.copy() if item is not None else None
+
+    def create(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        with self._lock:
+            item_id = self._state.next_id
+            self._state.next_id += 1
+            item = {"id": item_id, **payload}
+            self._state.items[item_id] = item
+            return item.copy()
+
+    def update(self, item_id: int, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            if item_id not in self._state.items:
+                return None
+            updated = {"id": item_id, **payload}
+            self._state.items[item_id] = updated
+            return updated.copy()
+
+    def delete(self, item_id: int) -> bool:
+        with self._lock:
+            return self._state.items.pop(item_id, None) is not None
+
+
+_STORAGE = DataStorage()
+
+
+def get_storage() -> DataStorage:
+    """FastAPI dependency returning the shared storage instance."""
+
+    return _STORAGE
+
+
+def list_data(storage: DataStorage) -> List[Dict[str, Any]]:
+    return storage.list()
+
+
+def get_data(storage: DataStorage, item_id: int) -> Optional[Dict[str, Any]]:
+    return storage.get(item_id)
+
+
+def create_data(storage: DataStorage, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return storage.create(payload)
+
+
+def update_data(
+    storage: DataStorage, item_id: int, payload: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    return storage.update(item_id, payload)
+
+
+def delete_data(storage: DataStorage, item_id: int) -> bool:
+    return storage.delete(item_id)
+

--- a/ai_influencer/webapp/templates/data.html
+++ b/ai_influencer/webapp/templates/data.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gestione dati - AI Influencer Control Hub</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="header-bar">
+        <h1>AI Influencer Control Hub</h1>
+        <nav class="app-nav">
+          <a href="/"{% if active_nav == "home" %} aria-current="page"{% endif %}
+            >Generazione contenuti</a
+          >
+          <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
+            >Analisi influencer</a
+          >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
+          <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
+            >Impostazioni</a
+          >
+        </nav>
+      </div>
+      <p>
+        Esplora e gestisci i dati demo disponibili attraverso le API REST. Utilizza gli
+        endpoint per creare, aggiornare o eliminare elementi di esempio.
+      </p>
+    </header>
+
+    <main class="layout">
+      <section class="card">
+        <h2>API disponibili</h2>
+        <ul>
+          <li><code>GET /api/data</code> &ndash; Elenca tutti gli elementi.</li>
+          <li><code>POST /api/data</code> &ndash; Crea un nuovo elemento.</li>
+          <li>
+            <code>GET /api/data/&lt;id&gt;</code> &ndash; Recupera un elemento specifico.
+          </li>
+          <li>
+            <code>PUT /api/data/&lt;id&gt;</code> &ndash; Aggiorna un elemento esistente.
+          </li>
+          <li>
+            <code>DELETE /api/data/&lt;id&gt;</code> &ndash; Rimuove un elemento.
+          </li>
+        </ul>
+        <p>
+          Gli endpoint restituiscono risposte JSON e gestiscono automaticamente errori
+          comuni come ID mancanti o payload non validi.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/ai_influencer/webapp/templates/index.html
+++ b/ai_influencer/webapp/templates/index.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/influencer.html
+++ b/ai_influencer/webapp/templates/influencer.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -17,6 +17,9 @@
           <a href="/influencer"{% if active_nav == "influencer" %} aria-current="page"{% endif %}
             >Analisi influencer</a
           >
+          <a href="/dati"{% if active_nav == "data" %} aria-current="page"{% endif %}
+            >Gestione dati</a
+          >
           <a href="/settings"{% if active_nav == "settings" %} aria-current="page"{% endif %}
             >Impostazioni</a
           >

--- a/ai_influencer/webapp/tests/test_data_endpoints.py
+++ b/ai_influencer/webapp/tests/test_data_endpoints.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from ai_influencer.webapp.main import app
+from ai_influencer.webapp.storage import delete_data, get_storage, list_data
+
+client = TestClient(app)
+
+
+def setup_module(module: object) -> None:
+    storage = get_storage()
+    for item in list_data(storage):
+        delete_data(storage, item["id"])
+
+
+def test_data_crud_flow() -> None:
+    create_response = client.post("/api/data", json={"name": "Elemento"})
+    assert create_response.status_code == 201
+    created = create_response.json()
+    assert "id" in created
+    data_id = created["id"]
+    assert created["name"] == "Elemento"
+
+    list_response = client.get("/api/data")
+    assert list_response.status_code == 200
+    items = list_response.json()["items"]
+    assert any(item["id"] == data_id for item in items)
+
+    get_response = client.get(f"/api/data/{data_id}")
+    assert get_response.status_code == 200
+    assert get_response.json()["name"] == "Elemento"
+
+    update_response = client.put(f"/api/data/{data_id}", json={"name": "Aggiornato"})
+    assert update_response.status_code == 200
+    assert update_response.json()["name"] == "Aggiornato"
+
+    delete_response = client.delete(f"/api/data/{data_id}")
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"deleted": True}
+
+    missing_response = client.get(f"/api/data/{data_id}")
+    assert missing_response.status_code == 404
+
+
+def test_create_requires_payload() -> None:
+    response = client.post("/api/data", json={})
+    assert response.status_code == 400
+
+
+def test_missing_item_responses() -> None:
+    assert client.get("/api/data/9999").status_code == 404
+    assert (
+        client.put("/api/data/9999", json={"name": "test"}).status_code == 404
+    )
+    assert client.delete("/api/data/9999").status_code == 404


### PR DESCRIPTION
## Summary
- add an in-memory storage module with CRUD helpers and a FastAPI dependency
- expose a data management page and REST endpoints backed by the shared storage
- update navigation and cover the new API with endpoint tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d76b1d6c3c8320b3ef414e5464534e