### PR TITLE
Refactor settings configuration to support multiple services

### DIFF
--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -482,6 +482,61 @@ textarea {
   color: rgba(240, 246, 252, 0.75);
 }
 
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.settings-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-size: 0.95rem;
+}
+
+.settings-table thead {
+  background: rgba(240, 246, 252, 0.06);
+}
+
+.settings-table th,
+.settings-table td {
+  padding: 0.75rem 0.85rem;
+  border-bottom: 1px solid rgba(240, 246, 252, 0.08);
+  text-align: left;
+}
+
+.settings-table tbody tr:hover {
+  background: rgba(240, 246, 252, 0.04);
+}
+
+.settings-table td.actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.table-hint {
+  display: inline-block;
+  background: rgba(240, 246, 252, 0.1);
+  color: rgba(240, 246, 252, 0.7);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.settings-dialog {
+  border: 1px solid rgba(240, 246, 252, 0.2);
+  border-radius: 16px;
+  padding: 1.5rem;
+  background: #0d1117;
+  color: inherit;
+  max-width: min(420px, 90vw);
+}
+
+.settings-dialog::backdrop {
+  background: rgba(1, 4, 9, 0.65);
+}
+
 .settings-form .input-hint {
   font-size: 0.8rem;
   color: rgba(240, 246, 252, 0.6);

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -26,57 +26,82 @@
         </nav>
       </div>
       <p>
-        Gestisci la chiave API e l'endpoint di OpenRouter utilizzati dall'applicazione.
+        Gestisci le integrazioni con i servizi esterni utilizzati dall'applicazione.
         Le modifiche vengono salvate immediatamente nell'ambiente di esecuzione.
       </p>
     </header>
 
     <main class="settings-layout">
       <section class="card settings-card">
-        <h2>Configurazione OpenRouter</h2>
+        <h2>Servizi esterni</h2>
         <p class="settings-description">
-          Inserisci la chiave API fornita da OpenRouter e, se necessario, un endpoint
-          personalizzato. La chiave viene mostrata in forma mascherata dopo il salvataggio.
+          Consulta e aggiorna la configurazione dei servizi supportati. Le chiavi API
+          vengono memorizzate nell'ambiente di esecuzione e mostrate solo in forma
+          mascherata. Gli endpoint personalizzati sono facoltativi.
         </p>
-        <div id="config-status" class="status-message empty">
-          Nessuna chiave configurata.
+        <div class="table-wrapper">
+          <table class="settings-table" id="services-table">
+            <thead>
+              <tr>
+                <th scope="col">Servizio</th>
+                <th scope="col">Endpoint</th>
+                <th scope="col">Chiave</th>
+                <th scope="col" class="actions">Azioni</th>
+              </tr>
+            </thead>
+            <tbody id="services-table-body">
+              <tr class="empty">
+                <td colspan="4">Caricamento servizi...</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
-        <form id="openrouter-form" class="form settings-form" autocomplete="off">
-          <label>
-            Chiave API
-            <input
-              type="password"
-              id="openrouter-api-key"
-              name="api_key"
-              placeholder="sk-..."
-              autocomplete="off"
-            />
-            <span class="input-hint">
-              Il valore inviato sovrascrive quello attualmente configurato.
-            </span>
-          </label>
-          <label>
-            Endpoint personalizzato (facoltativo)
-            <input
-              type="url"
-              id="openrouter-base-url"
-              name="base_url"
-              placeholder="https://openrouter.ai/api/v1"
-              autocomplete="off"
-            />
-            <span class="input-hint">
-              Lascia vuoto per mantenere l'endpoint predefinito di OpenRouter.
-            </span>
-          </label>
-          <div class="settings-actions">
-            <button type="submit">Salva configurazione</button>
-            <button type="button" id="clear-settings" class="button-secondary">
-              Pulisci form
-            </button>
-          </div>
-        </form>
       </section>
     </main>
+
+    <dialog id="service-dialog" class="settings-dialog">
+      <form
+        id="service-form"
+        class="form settings-form"
+        method="dialog"
+        autocomplete="off"
+      >
+        <h3 id="service-dialog-title">Modifica servizio</h3>
+        <input type="hidden" id="service-id" name="service_id" />
+        <p id="service-env-hint" class="input-hint"></p>
+        <label>
+          Chiave API
+          <input
+            type="password"
+            id="service-api-key"
+            name="api_key"
+            placeholder="sk-..."
+            autocomplete="off"
+          />
+          <span class="input-hint">
+            Inserisci una nuova chiave per sostituire quella esistente.
+          </span>
+        </label>
+        <label>
+          Endpoint personalizzato (facoltativo)
+          <input
+            type="url"
+            id="service-endpoint"
+            name="endpoint"
+            autocomplete="off"
+          />
+          <span class="input-hint">
+            Lascia vuoto per utilizzare l'endpoint predefinito del servizio.
+          </span>
+        </label>
+        <div class="settings-actions">
+          <button type="submit">Salva</button>
+          <button type="button" id="service-cancel" class="button-secondary">
+            Annulla
+          </button>
+        </div>
+      </form>
+    </dialog>
 
     <script src="/static/settings.js" type="module"></script>
   </body>

--- a/ai_influencer/webapp/tests/test_settings.py
+++ b/ai_influencer/webapp/tests/test_settings.py
@@ -1,0 +1,103 @@
+import os
+from typing import Dict
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ai_influencer.webapp.main import SERVICE_REGISTRY, app
+
+
+@pytest.fixture(name="client")
+def fixture_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    for metadata in SERVICE_REGISTRY.values():
+        if metadata.api_key_env:
+            monkeypatch.delenv(metadata.api_key_env, raising=False)
+        if metadata.endpoint_env:
+            monkeypatch.delenv(metadata.endpoint_env, raising=False)
+    return TestClient(app)
+
+
+def _get_openrouter_payload(client: TestClient) -> Dict[str, object]:
+    response = client.get("/api/config/services")
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, dict)
+    services = payload.get("services", [])
+    assert services and services[0]["id"] == "openrouter"
+    return services[0]
+
+
+def test_list_services_uses_default_configuration(client: TestClient) -> None:
+    service = _get_openrouter_payload(client)
+    assert service["endpoint"] == "https://openrouter.ai/api/v1"
+    assert service["uses_default_endpoint"] is True
+    assert service["has_api_key"] is False
+    assert service["api_key_preview"] is None
+    assert service["env"] == {
+        "api_key": "OPENROUTER_API_KEY",
+        "endpoint": "OPENROUTER_BASE_URL",
+    }
+
+
+def test_update_service_persists_api_key_and_endpoint(client: TestClient) -> None:
+    response = client.post(
+        "/api/config/services/openrouter",
+        json={
+            "api_key": "sk-testvalue",
+            "endpoint": "https://example.com/api",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    service = payload["service"]
+    assert service["has_api_key"] is True
+    assert service["api_key_preview"].endswith("alue")
+    assert service["uses_default_endpoint"] is False
+    assert service["endpoint"] == "https://example.com/api"
+    assert os.environ["OPENROUTER_API_KEY"] == "sk-testvalue"
+    assert os.environ["OPENROUTER_BASE_URL"] == "https://example.com/api"
+
+    refreshed = _get_openrouter_payload(client)
+    assert refreshed["has_api_key"] is True
+    assert refreshed["api_key_preview"].endswith("alue")
+    assert refreshed["uses_default_endpoint"] is False
+    assert refreshed["endpoint"] == "https://example.com/api"
+
+
+def test_update_service_allows_clearing_endpoint(client: TestClient) -> None:
+    client.post(
+        "/api/config/services/openrouter",
+        json={"endpoint": "https://example.com/custom"},
+    )
+    response = client.post(
+        "/api/config/services/openrouter",
+        json={"endpoint": None},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    service = payload["service"]
+    assert service["uses_default_endpoint"] is True
+    assert service["endpoint"] == "https://openrouter.ai/api/v1"
+    assert "OPENROUTER_BASE_URL" not in os.environ
+
+
+def test_update_service_rejects_unknown_service(client: TestClient) -> None:
+    response = client.post("/api/config/services/unknown", json={"api_key": "x"})
+    assert response.status_code == 404
+
+
+def test_update_service_validates_payload(client: TestClient) -> None:
+    response = client.post("/api/config/services/openrouter", json={})
+    assert response.status_code == 422
+
+    response = client.post(
+        "/api/config/services/openrouter",
+        json={"endpoint": "notaurl"},
+    )
+    assert response.status_code == 422
+
+    response = client.post(
+        "/api/config/services/openrouter",
+        json={"api_key": ""},
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add service metadata and new configuration endpoints for service-specific secrets
- refresh the settings UI to display services in a table with an edit dialog
- update frontend logic and styling to manage service edits and masking, and add API tests for the new flow

## Testing
- PYTHONPATH=. pytest ai_influencer/webapp/tests

------
https://chatgpt.com/codex/tasks/task_e_68d774021b2083208f64c7bd3bfbd623