### PR TITLE
Add official platform service configuration guidance to settings

### DIFF
--- a/ai_influencer/webapp/static/settings.js
+++ b/ai_influencer/webapp/static/settings.js
@@ -133,11 +133,23 @@ function openServiceDialog(serviceId) {
   titleEl.textContent = `Modifica ${service.name}`;
 
   const envHints = [];
-  if (service.env?.api_key) {
-    envHints.push(`Chiave: ${service.env.api_key}`);
-  }
-  if (service.env?.endpoint) {
-    envHints.push(`Endpoint: ${service.env.endpoint}`);
+  if (service.env && typeof service.env === 'object') {
+    Object.entries(service.env).forEach(([key, value]) => {
+      if (!value) return;
+      let label;
+      if (key === 'api_key') {
+        label = `Chiave: ${value}`;
+      } else if (key === 'endpoint') {
+        label = `Endpoint: ${value}`;
+      } else {
+        const friendlyKey = key
+          .split('_')
+          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .join(' ');
+        label = `${friendlyKey}: ${value}`;
+      }
+      envHints.push(label);
+    });
   }
   envHintEl.textContent = envHints.length
     ? `Variabili ambiente: ${envHints.join(' · ')}`

--- a/ai_influencer/webapp/static/styles.css
+++ b/ai_influencer/webapp/static/styles.css
@@ -482,6 +482,60 @@ textarea {
   color: rgba(240, 246, 252, 0.75);
 }
 
+.settings-guidelines {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 1.75rem;
+  counter-reset: item;
+}
+
+.settings-guidelines > li {
+  line-height: 1.6;
+}
+
+.settings-guidelines h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.settings-sublist {
+  margin: 0.75rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.settings-sublist li {
+  color: rgba(240, 246, 252, 0.78);
+}
+
+.settings-note {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid rgba(56, 139, 253, 0.7);
+  background: rgba(56, 139, 253, 0.08);
+  color: rgba(201, 218, 255, 0.9);
+  border-radius: 8px;
+}
+
+.settings-code {
+  margin: 0.75rem 0 0;
+  padding: 0.85rem 1rem;
+  background: rgba(10, 14, 23, 0.8);
+  border: 1px solid rgba(240, 246, 252, 0.12);
+  border-radius: 12px;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.settings-code code {
+  font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, monospace;
+  color: rgba(219, 234, 255, 0.95);
+  white-space: pre;
+}
+
 .table-wrapper {
   overflow-x: auto;
 }

--- a/ai_influencer/webapp/templates/settings.html
+++ b/ai_influencer/webapp/templates/settings.html
@@ -56,6 +56,197 @@
             </tbody>
           </table>
         </div>
+
+      </section>
+
+      <section class="card settings-card">
+        <h2>Linee guida per le integrazioni ufficiali</h2>
+        <ol class="settings-guidelines">
+          <li>
+            <h3>Endpoints “sicuri” (API ufficiali) e campi immagini</h3>
+            <ul class="settings-sublist">
+              <li>
+                <strong>YouTube Data API v3</strong> –
+                <code>channels.list?part=snippet,statistics&amp;id=...</code> restituisce
+                gli URL delle miniature in
+                <code>snippet.thumbnails</code> (default/medium/high). Documentazione:
+                Google for Developers.
+              </li>
+              <li>
+                <strong>Instagram Graph API – Business Discovery</strong> –
+                <code>/{ig-user-id}?fields=business_discovery.username(&lt;handle&gt;){...}</code>
+                fornisce <code>profile_picture_url</code>,
+                <code>followers_count</code> e le immagini dei post. Richiede account
+                Business/Creator collegato a una Pagina Facebook. Documentazione:
+                Meta for Developers.
+              </li>
+              <li>
+                <strong>X (Twitter) API v2</strong> –
+                <code>GET /2/users/by/username/{username}?user.fields=profile_image_url,...</code>
+                fornisce avatar in più risoluzioni, descrizione e metriche pubbliche.
+                Documentazione: X Developer Platform.
+              </li>
+              <li>
+                <strong>TikTok API v2</strong> –
+                <code>GET https://open.tiktokapis.com/v2/user/info/</code> (scope OAuth
+                richiesto) restituisce dati profilo e immagini/thumbnail disponibili.
+                Documentazione: TikTok for Developers.
+              </li>
+            </ul>
+            <p class="settings-note">
+              Nota: i vecchi endpoint Bing Image Search stanno cambiando; valutare
+              provider alternativi o SERP wrapper nel rispetto delle licenze.
+            </p>
+          </li>
+          <li>
+            <h3>Architettura modulare con scraping disattivabile</h3>
+            <p>
+              Utilizzare variabili d'ambiente per attivare o disattivare lo scraping e
+              definire le piattaforme abilitate. Esempio di configurazione:
+            </p>
+            <pre class="settings-code"><code>SCRAPING_ENABLED=false
+PLATFORMS=youtube,instagram,x,tiktok
+YOUTUBE_API_KEY=...
+X_BEARER_TOKEN=...
+FB_APP_ID=...
+FB_APP_SECRET=...
+IG_SYSTEM_USER_TOKEN=...
+TIKTOK_CLIENT_ID=...
+TIKTOK_CLIENT_SECRET=...</code></pre>
+            <p>
+              La pipeline consigliata prevede: normalizzazione input, fetch tramite API
+              ufficiali, normalizzazione dati, eventuale scraping opzionale, layer di
+              policy, cache/CDN e persistenza su database.
+            </p>
+          </li>
+          <li>
+            <h3>Implementazione pratica (Node/TypeScript) — API ufficiali first</h3>
+            <pre class="settings-code"><code>// pseudo-TS robusto
+type Platform = 'youtube'|'instagram'|'x'|'tiktok';
+interface FetchOptions { scrapingEnabled: boolean }
+
+export async function fetchInfluencer(platform: Platform, handleOrUrl: string, opt: FetchOptions){
+  const target = await resolveHandle(platform, handleOrUrl);
+  const apiData = await fetchViaOfficialAPI(platform, target);
+  let media = extractMedia(apiData);
+
+  if (needsMore(media) &amp;&amp; opt.scrapingEnabled) {
+    const scraped = await tryScrape(platform, target);
+    media = mergePreferAPI(media, scraped);
+  }
+  return normalize(platform, target, apiData, media);
+}</code></pre>
+            <p>Esempi di chiamate semplificate:</p>
+            <pre class="settings-code"><code># YouTube – channel
+curl "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics&amp;id=CHANNEL_ID&amp;key=$YOUTUBE_API_KEY"
+
+# Instagram – business_discovery
+curl "https://graph.facebook.com/v19.0/{IG_USER_ID}?\
+fields=business_discovery.username(INFLUENCER){username,biography,profile_picture_url,followers_count,media_count,media.limit(12){id,media_type,media_url,thumbnail_url,caption,timestamp}}&amp;\
+access_token=$IG_SYSTEM_USER_TOKEN"
+
+# X – user by username
+curl -H "Authorization: Bearer $X_BEARER_TOKEN" \\n"https://api.x.com/2/users/by/username/USERNAME?user.fields=profile_image_url,public_metrics,description,verified"
+
+# TikTok – user info (v2)
+curl -H "Authorization: Bearer $TIKTOK_ACCESS_TOKEN" \\n"https://open.tiktokapis.com/v2/user/info/"</code></pre>
+          </li>
+          <li>
+            <h3>Scraping intelligente (fallback opzionale)</h3>
+            <ul class="settings-sublist">
+              <li>Attivare solo quando i campi essenziali mancano dalle API.</li>
+              <li>
+                Utilizzare Playwright con profili stealth, rotazione proxy e rispetto di
+                <code>robots.txt</code> dove applicabile.
+              </li>
+              <li>
+                Limitare lo scraping a metadati pubblici, con rate cap (es. una richiesta
+                al minuto per profilo) e logging <code>collected_via='scraping'</code>.
+              </li>
+              <li>
+                Governare l'attivazione tramite env come
+                <code>SCRAPING_ENABLED</code>, <code>SCRAPE_X</code>,
+                <code>SCRAPE_IG</code>, <code>SCRAPE_LEVEL</code>.
+              </li>
+              <li>
+                Ricordare i rischi legali: le piattaforme possono vietare lo scraping.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <h3>n8n/cron: orchestrazione step-by-step</h3>
+            <p>Workflow suggerito per processare un handle:</p>
+            <ul class="settings-sublist">
+              <li>HTTP Webhook → riceve <code>{platform, handle}</code>.</li>
+              <li>Switch per piattaforma.</li>
+              <li>HTTP Request → chiama l'API interna <code>/fetchInfluencer</code>.</li>
+              <li>
+                IF <code>collected_via == scraping</code> → impostare flag “review
+                needed”.
+              </li>
+              <li>Postgres Node → upsert di <code>influencer</code> e <code>media</code>.</li>
+              <li>
+                Function → normalizza/filtra immagini (solo HTTPS, dimensioni minime).
+              </li>
+              <li>CDN (opzionale) → download consentito solo con licenza adeguata.</li>
+              <li>Slack/Email → report con differenze e anomalie.</li>
+              <li>Error branch → backoff + retry con jitter.</li>
+            </ul>
+          </li>
+          <li>
+            <h3>Verifica, rate-limit e resilienza</h3>
+            <ul class="settings-sublist">
+              <li>Backoff esponenziale per status 429/5xx.</li>
+              <li>Supportare ETag/If-None-Match (es. YouTube).</li>
+              <li>Paginare correttamente business_discovery (cursor-based).</li>
+              <li>Deduplicare su <code>media_id</code>/URL e validare le immagini via HEAD.</li>
+            </ul>
+          </li>
+          <li>
+            <h3>Rischi, blind spot, trade-off</h3>
+            <ul class="settings-sublist">
+              <li>
+                Instagram: business_discovery richiede account Business/Creator collegato
+                a Pagina.
+              </li>
+              <li>TikTok: molti endpoint necessitano OAuth dell'utente target.</li>
+              <li>Scraping: fragile ai cambi DOM e potenziali violazioni ToS.</li>
+              <li>
+                Licenze immagini: un URL non equivale al diritto di redistribuzione
+                commerciale.
+              </li>
+              <li>Attenzione al decommissioning di Bing Image Search.</li>
+            </ul>
+          </li>
+          <li>
+            <h3>Alternative concrete</h3>
+            <ul class="settings-sublist">
+              <li>Solo API ufficiali, senza scraping → massima compliance.</li>
+              <li>
+                API ufficiali + provider terzi con licenza per immagini correlate (es.
+                SERP wrapper, SearchApi) → verificare ToS.
+              </li>
+              <li>
+                API ufficiali + scraping mirato in whitelist (es. solo avatar mancanti) →
+                riduce il rischio.
+              </li>
+            </ul>
+          </li>
+          <li>
+            <h3>Checklist “pronta all’uso”</h3>
+            <ul class="settings-sublist">
+              <li>Variabili env impostate, <code>SCRAPING_ENABLED=false</code> di default.</li>
+              <li>
+                Chiavi/OAuth configurati per YouTube, Instagram, X, TikTok (se necessari).
+              </li>
+              <li>Moduli per piattaforma con test e mock di rate-limit.</li>
+              <li>Normalizer e schema Postgres creati.</li>
+              <li>Log delle fonti (API vs scraping) con audit diff.</li>
+              <li>Workflow n8n con retry/backoff e report.</li>
+              <li>Policy immagini e licenze definite.</li>
+            </ul>
+          </li>
+        </ol>
       </section>
     </main>
 

--- a/ai_influencer/webapp/tests/test_settings.py
+++ b/ai_influencer/webapp/tests/test_settings.py
@@ -12,8 +12,10 @@ def fixture_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     for metadata in SERVICE_REGISTRY.values():
         if metadata.api_key_env:
             monkeypatch.delenv(metadata.api_key_env, raising=False)
-        if metadata.endpoint_env:
-            monkeypatch.delenv(metadata.endpoint_env, raising=False)
+        if metadata.base_url_env:
+            monkeypatch.delenv(metadata.base_url_env, raising=False)
+        for env_name in metadata.extra_env.values():
+            monkeypatch.delenv(env_name, raising=False)
     return TestClient(app)
 
 
@@ -23,8 +25,20 @@ def _get_openrouter_payload(client: TestClient) -> Dict[str, object]:
     payload = response.json()
     assert isinstance(payload, dict)
     services = payload.get("services", [])
-    assert services and services[0]["id"] == "openrouter"
-    return services[0]
+    assert services
+    for service in services:
+        if service["id"] == "openrouter":
+            return service
+    pytest.fail("OpenRouter service missing")
+
+
+def _service_map(client: TestClient) -> Dict[str, Dict[str, object]]:
+    response = client.get("/api/config/services")
+    assert response.status_code == 200
+    payload = response.json()
+    services = payload.get("services", [])
+    assert isinstance(services, list)
+    return {service["id"]: service for service in services}
 
 
 def test_list_services_uses_default_configuration(client: TestClient) -> None:
@@ -36,6 +50,43 @@ def test_list_services_uses_default_configuration(client: TestClient) -> None:
     assert service["env"] == {
         "api_key": "OPENROUTER_API_KEY",
         "endpoint": "OPENROUTER_BASE_URL",
+    }
+
+
+def test_service_registry_includes_official_integrations(client: TestClient) -> None:
+    services = _service_map(client)
+
+    youtube = services["youtube"]
+    assert youtube["name"] == "YouTube Data API v3"
+    assert youtube["endpoint"] == "https://www.googleapis.com/youtube/v3"
+    assert youtube["uses_default_endpoint"] is True
+    assert youtube["env"] == {
+        "api_key": "YOUTUBE_API_KEY",
+        "endpoint": "YOUTUBE_API_BASE_URL",
+    }
+
+    instagram = services["instagram"]
+    assert instagram["endpoint"] == "https://graph.facebook.com/v19.0"
+    assert instagram["env"] == {
+        "api_key": "IG_SYSTEM_USER_TOKEN",
+        "endpoint": "IG_GRAPH_API_BASE_URL",
+        "app_id": "FB_APP_ID",
+        "app_secret": "FB_APP_SECRET",
+    }
+
+    x_service = services["x"]
+    assert x_service["endpoint"] == "https://api.x.com/2"
+    assert x_service["env"] == {
+        "api_key": "X_BEARER_TOKEN",
+        "endpoint": "X_API_BASE_URL",
+    }
+
+    tiktok = services["tiktok"]
+    assert tiktok["endpoint"] == "https://open.tiktokapis.com/v2"
+    assert tiktok["env"] == {
+        "api_key": "TIKTOK_CLIENT_SECRET",
+        "endpoint": "TIKTOK_API_BASE_URL",
+        "client_id": "TIKTOK_CLIENT_ID",
     }
 
 


### PR DESCRIPTION
## Summary
- fix the settings update payload handling and add service registry entries for YouTube, Instagram, X and TikTok official APIs
- surface environment variable hints in the UI with new integration guidelines for configuring official data sources
- cover the new services with FastAPI tests and refresh settings page styling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d77beec2d883209cfd8e8015ec42ab