### PR TITLE
Add n8n orchestration service to Docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Configura queste variabili prima di avviare gli script o i container. Possono es
 | `OPENROUTER_APP_TITLE` | ➖ | Nome dell'applicazione riportato negli header verso OpenRouter, utile per il billing dashboard. | Webapp |
 | `OPENROUTER_APP_URL` | ➖ | URL pubblico del progetto da mostrare nel billing dashboard di OpenRouter. | Webapp |
 | `BASE_MODEL` | ➖ | Percorso del checkpoint SDXL da utilizzare di default nel training LoRA. | Script `train_lora.sh`, workflow n8n |
+| `N8N_BASIC_AUTH_ACTIVE` | ➖ | Abilita/disabilita la Basic Auth sul pannello e sui webhook (`true` di default). | Servizio Docker `n8n_local` |
+| `N8N_BASIC_AUTH_USER` | ➖ | Username per l'accesso all'interfaccia n8n e ai webhook protetti. | Servizio Docker `n8n_local` |
+| `N8N_BASIC_AUTH_PASSWORD` | ➖ | Password associata allo user Basic Auth n8n. | Servizio Docker `n8n_local` |
+| `N8N_WEBHOOK_URL` | ➖ | URL pubblico dei webhook (utile dietro tunnel/reverse proxy). | Servizio Docker `n8n_local` |
 | `HF_TOKEN` | ➖ | Token Hugging Face per scaricare modelli privati o ad accesso limitato. | Script `bootstrap_models.py`, CLI |
 
 > Suggerimento: crea un file `ai_influencer/docker/.env` copiando `ai_influencer/docker/.env.example` e aggiorna i valori sensibili una sola volta.
@@ -85,6 +89,7 @@ Il progetto **Influencer AI** fornisce un flusso end-to-end per costruire una pe
    - `comfyui_local` (interfaccia ComfyUI su http://localhost:8188)
    - `kohya_local` (ambiente kohya_ss per LoRA)
    - `ai_influencer_webapp` (Control Hub su http://localhost:8000)
+   - `n8n_local` (automazione no-code n8n su http://localhost:5678)
 
 ## Esecuzione della pipeline
 Esegui i comandi nel container `ai_influencer_tools` salvo diversa indicazione:
@@ -259,7 +264,7 @@ ai_influencer/
 ```
 
 - **GUI desktop** (`scripts/gui_app.py`): fornisce una finestra Tkinter con wizard per API key, preparazione dataset, generazione testo/immagini, QC e augment. Ogni pulsante invoca gli script CLI corrispondenti mostrando i log in tempo reale.
-- **Workflow n8n** (`n8n/flow.json`): definisce un webhook che esegue sequenzialmente `prepare_dataset.py`, `openrouter_batch.py` e step collegati all'interno del container Docker; il nodo finale "Train LoRA" accetta un campo JSON `base_model` per scegliere il checkpoint da passare allo script.
+- **Workflow n8n** (`n8n/flow.json` + servizio `n8n_local`): espone il webhook `/webhook/ai-influencer-hybrid` e, tramite `docker exec`, orchestra gli script nei container `ai_influencer_tools` e `kohya_local` (con supporto al parametro JSON `base_model`).
 - **Script PowerShell** (`scripts/start_machine.ps1`, `scripts/stop_machine.ps1`): facilitano l'avvio/arresto dei container su Windows.
 
 ## Troubleshooting rapido

--- a/ai_influencer/docker/docker-compose.yaml
+++ b/ai_influencer/docker/docker-compose.yaml
@@ -72,3 +72,32 @@ services:
       "
     ports:
       - "8000:8000"
+
+  n8n:
+    build:
+      context: ..
+      dockerfile: docker/n8n.Dockerfile
+    container_name: n8n_local
+    depends_on:
+      - tools
+      - kohya
+    environment:
+      - N8N_HOST=localhost
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=http
+      - N8N_BASIC_AUTH_ACTIVE=${N8N_BASIC_AUTH_ACTIVE:-true}
+      - N8N_BASIC_AUTH_USER=${N8N_BASIC_AUTH_USER:-admin}
+      - N8N_BASIC_AUTH_PASSWORD=${N8N_BASIC_AUTH_PASSWORD:-admin}
+      - N8N_USER_FOLDER=/data
+      - N8N_IMPORT_EXPORT_DIR=/imports
+      - WEBHOOK_URL=${N8N_WEBHOOK_URL:-http://localhost:5678/}
+    ports:
+      - "5678:5678"
+    volumes:
+      - n8n_data:/data
+      - ../n8n:/imports
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+volumes:
+  n8n_data:

--- a/ai_influencer/docker/n8n.Dockerfile
+++ b/ai_influencer/docker/n8n.Dockerfile
@@ -1,0 +1,6 @@
+FROM n8nio/n8n:1.68.3
+
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends docker-cli \
+    && rm -rf /var/lib/apt/lists/*

--- a/ai_influencer/n8n/flow.json
+++ b/ai_influencer/n8n/flow.json
@@ -16,7 +16,7 @@
     },
     {
       "parameters": {
-        "command": "python3 scripts/prepare_dataset.py --in data/input_raw --out data/cleaned --do_rembg --do_facecrop"
+        "command": "docker exec -w /workspace ai_influencer_tools python3 scripts/prepare_dataset.py --in data/input_raw --out data/cleaned --do_rembg --do_facecrop"
       },
       "name": "Docker Exec - Clean",
       "type": "n8n-nodes-base.executeCommand",
@@ -28,7 +28,7 @@
     },
     {
       "parameters": {
-        "command": "python3 scripts/openrouter_batch.py --prompt_bank scripts/prompt_bank.yaml --out data/synth_openrouter"
+        "command": "docker exec -w /workspace ai_influencer_tools python3 scripts/openrouter_batch.py --prompt_bank scripts/prompt_bank.yaml --out data/synth_openrouter"
       },
       "name": "OpenRouter Batch",
       "type": "n8n-nodes-base.executeCommand",
@@ -40,7 +40,7 @@
     },
     {
       "parameters": {
-        "command": "python3 scripts/qc_face_sim.py --ref data/cleaned --cand data/synth_openrouter --out data/qc_passed --minsim 0.34"
+        "command": "docker exec -w /workspace ai_influencer_tools python3 scripts/qc_face_sim.py --ref data/cleaned --cand data/synth_openrouter --out data/qc_passed --minsim 0.34"
       },
       "name": "QC Face",
       "type": "n8n-nodes-base.executeCommand",
@@ -52,7 +52,7 @@
     },
     {
       "parameters": {
-        "command": "python3 scripts/augment_and_caption.py --in data/qc_passed --out data/augment --captions data/captions --num_aug 1 --meta data/synth_openrouter/manifest.json"
+        "command": "docker exec -w /workspace ai_influencer_tools python3 scripts/augment_and_caption.py --in data/qc_passed --out data/augment --captions data/captions --num_aug 1 --meta data/synth_openrouter/manifest.json"
       },
       "name": "Augment+Caption",
       "type": "n8n-nodes-base.executeCommand",
@@ -64,7 +64,7 @@
     },
     {
       "parameters": {
-        "command": "={{\"bash scripts/train_lora.sh\" + ($json[\"base_model\"] ? \" --base-model \\\"\" + $json[\"base_model\"] + \"\\\"\" : \"\")}}"
+        "command": "={{\"docker exec -w /workspace kohya_local bash -lc '\" + ($json[\"base_model\"] ? \"BASE_MODEL=\\\"\" + $json[\"base_model\"] + \"\\\" \" : \"\") + \"bash scripts/train_lora.sh'\"}}"
       },
       "name": "Train LoRA",
       "type": "n8n-nodes-base.executeCommand",


### PR DESCRIPTION
## Summary
- add an n8n container to the Docker stack with a custom image capable of orchestrating existing services via docker exec
- update the packaged workflow to call the pipeline scripts inside the ai_influencer_tools and kohya_local containers
- document the new automation entrypoint, environment variables, and webhook usage across the project READMEs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79912d5648320a7a7d4da55b93146