### PR TITLE
Document Control Hub API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,18 @@ Se non specifichi nulla verrà usato `/workspace/models/base/sdxl.safetensors`. 
 ## Control Hub web
 Il servizio `ai_influencer_webapp` fornisce un **Control Hub API-first** su [http://localhost:8000](http://localhost:8000). Tutte le interazioni avvengono via endpoint REST; l'interfaccia HTML è stata rimossa a favore della documentazione interattiva generata automaticamente.
 
+### Endpoint API
+| Endpoint | Metodo | Payload richiesto | Campi principali della risposta |
+| -------- | ------ | ----------------- | -------------------------------- |
+| `/api/models` | GET | Nessun payload. | Oggetto con chiave `models`, lista di modelli con `id`, `name`, `provider`, `capabilities`, `context_length`, `pricing`, `pricing_display`. |
+| `/api/generate/text` | POST | JSON `{ "model": string, "prompt": string }`. | Oggetto `{ "content": string }` con il testo generato. |
+| `/api/generate/image` | POST | JSON `{ "model": string, "prompt": string, "negative_prompt"?: string, "width": int, "height": int, "steps"?: int, "guidance"?: float }`. | Oggetto `{ "image": string, "is_remote": bool }`, dove `image` è base64 o URL remoto. |
+| `/api/generate/video` | POST | JSON `{ "model": string, "prompt": string, "duration"?: number, "size"?: string }`. | Oggetto `{ "video": string, "is_remote": bool }`, con base64 inline o URL streaming. |
+| `/api/influencer` | POST | JSON `{ "identifier": string, "method"?: "official" \| "scrape" }`. | Oggetto con `profile`, `metrics`, `media`, `identifier`, `method`, `retrieved_at`. `media` contiene schede con `id`, `titolo`, `tipo`, `testo_post`, `image_url`, `image_base64`, `thumbnail_url`, `success_score`, `original_url`, `pubblicato_il`, `transcript`. |
+| `/healthz` | GET | Nessun payload. | Oggetto `{ "status": "ok" }`. |
+
+Per i dettagli completi consulta [docs/funzionalita.rm](docs/funzionalita.rm).
+
 ### Swagger / OpenAPI
 - Avvia lo stack Docker (`docker compose -f ai_influencer/docker/docker-compose.yaml up -d`).
 - Apri <http://localhost:8000/docs> per accedere alla pagina Swagger auto-generata da FastAPI.

--- a/docs/funzionalita.rm
+++ b/docs/funzionalita.rm
@@ -1,0 +1,76 @@
+# Control Hub API – Dettaglio funzionalità
+
+Questa panoramica descrive nel dettaglio gli endpoint esposti da `ai_influencer/webapp/main.py`, includendo campi obbligatori, opzionali e struttura delle risposte.
+
+## GET /api/models
+- **Descrizione:** restituisce i modelli OpenRouter disponibili con una rappresentazione compatta per l'interfaccia.
+- **Request body:** nessuno.
+- **Response:**
+  - `models` (array): elenco dei modelli.
+    - `id` (string)
+    - `name` (string)
+    - `provider` (string)
+    - `capabilities` (array di string)
+    - `context_length` (number \| null)
+    - `pricing` (object): payload originale OpenRouter.
+    - `pricing_display` (string \| null): prezzo sintetico se ricavabile.
+
+## POST /api/generate/text
+- **Descrizione:** esegue una chat completion OpenRouter e restituisce il testo prodotto.
+- **Request body (JSON):**
+  - `model` (string, obbligatorio)
+  - `prompt` (string, obbligatorio)
+- **Response:**
+  - `content` (string): testo completo generato dal modello.
+
+## POST /api/generate/image
+- **Descrizione:** invia una richiesta di generazione immagine.
+- **Request body (JSON):**
+  - `model` (string, obbligatorio)
+  - `prompt` (string, obbligatorio)
+  - `negative_prompt` (string, opzionale)
+  - `width` (integer, obbligatorio; range 256–2048)
+  - `height` (integer, obbligatorio; range 256–2048)
+  - `steps` (integer, opzionale; range 1–100)
+  - `guidance` (float, opzionale; range 0–50)
+- **Response:**
+  - `image` (string): contenuto base64 o URL remoto del media generato.
+  - `is_remote` (boolean): indica se `image` è un URL remoto (`true`) oppure un blob inline (`false`).
+
+## POST /api/generate/video
+- **Descrizione:** esegue la generazione di un breve video.
+- **Request body (JSON):**
+  - `model` (string, obbligatorio)
+  - `prompt` (string, obbligatorio)
+  - `duration` (number, opzionale; range 1–60 secondi)
+  - `size` (string, opzionale; es. `1024x576`)
+- **Response:**
+  - `video` (string): base64 inline o URL remoto.
+  - `is_remote` (boolean): `true` se la risorsa è fornita come URL.
+
+## POST /api/influencer
+- **Descrizione:** simula la raccolta di insight per un profilo social.
+- **Request body (JSON):**
+  - `identifier` (string, obbligatorio): handle o URL.
+  - `method` (string, opzionale; valori ammessi `official`, `scrape`; default `official`).
+- **Response:**
+  - `profile` (object):
+    - `handle` (string)
+    - `nome` (string)
+    - `piattaforma` (string)
+    - `fonte_dati` (string)
+  - `metrics` (object):
+    - `follower` (integer)
+    - `engagement_rate` (string)
+    - `crescita_30g` (string)
+    - `media_view` (integer)
+  - `media` (array di object): ciascun item include `id`, `titolo`, `tipo`, `testo_post`, `image_url`, `image_base64`, `thumbnail_url`, `success_score`, `original_url`, `pubblicato_il`, `transcript` (null per i post immagine).
+  - `identifier` (string): handle normalizzato.
+  - `method` (string): valore effettivo (`official` o `scrape`).
+  - `retrieved_at` (string, ISO 8601): timestamp della simulazione.
+
+## GET /healthz
+- **Descrizione:** health check minimale.
+- **Request body:** nessuno.
+- **Response:**
+  - `status` (string): valore fisso `"ok"`.


### PR DESCRIPTION
## Summary
- add an API endpoint summary table to the Control Hub section of the README
- link to a new detailed reference document for each REST resource
- document request and response fields for all FastAPI routes exposed by the webapp

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79ce110c08320a1d0a000fd88b915