### PR TITLE
Update n8n Docker base image tag

### DIFF
--- a/ai_influencer/docker/n8n.Dockerfile
+++ b/ai_influencer/docker/n8n.Dockerfile
@@ -1,4 +1,4 @@
-FROM n8nio/n8n:1.68.3
+FROM n8nio/n8n:1.113.3
 
 USER root
 RUN apt-get update \


### PR DESCRIPTION
## Summary
- bump the n8n Docker image used by the local automation service to version 1.113.3 so the image can be pulled successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79cfe8758832095ea38de36572e70