### PR TITLE
feat: enrich generation prompts with influencer context

### DIFF
--- a/ai_influencer/webapp/main.py
+++ b/ai_influencer/webapp/main.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import base64
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from ai_influencer.webapp.openrouter import (
     OpenRouterClient,
@@ -16,12 +16,124 @@ from ai_influencer.webapp.openrouter import (
     summarize_models,
 )
 
+INFLUENCER_STORE: Dict[str, Dict[str, str]] = {
+    "aurora_rise": {
+        "story": (
+            "Aurora Rise ha iniziato come fotografa itinerante e ora racconta "
+            "viaggi spaziali immaginari con un focus su comunità inclusive."
+        ),
+        "personality": (
+            "Ottimista visionaria, parla con tono ispirazionale e calore umano, "
+            "invogliando il pubblico a immaginare futuri luminosi."
+        ),
+    },
+    "luca_wave": {
+        "story": (
+            "Luca Wave è un ex DJ diventato storyteller digitale che mescola "
+            "memorie costiere e tecnologia immersiva."
+        ),
+        "personality": (
+            "Rilassato ma curioso, usa un linguaggio poetico e vibrazioni da "
+            "tramonto mediterraneo per mettere a proprio agio chi lo segue."
+        ),
+    },
+}
+
+
 app = FastAPI(title="AI Influencer Control Hub")
 
 
 async def get_client() -> OpenRouterClient:
     return OpenRouterClient()
-class TextGenerationRequest(BaseModel):
+
+
+def _resolve_influencer_context(
+    payload: InfluencerContext,
+) -> Tuple[str, str]:
+    if payload.story and payload.personality:
+        return payload.story, payload.personality
+
+    if payload.influencer_id:
+        lookup_key = payload.influencer_id.lower()
+        record = INFLUENCER_STORE.get(lookup_key)
+        if not record:
+            raise HTTPException(status_code=404, detail="Influencer context not found")
+        return record["story"], record["personality"]
+
+    raise HTTPException(status_code=422, detail="Contesto influencer mancante")
+
+
+def _enrich_text_prompt(base_prompt: str, story: str, personality: str) -> str:
+    prompt = base_prompt.strip()
+    context = (
+        f"Storia dell'influencer: {story}\n"
+        f"Personalità e tono: {personality}"
+    )
+    return f"{prompt}\n\n{context}" if prompt else context
+
+
+def _enrich_visual_prompt(base_prompt: str, story: str, personality: str) -> str:
+    prompt = base_prompt.strip()
+    visual_context = (
+        f"Ispirazione narrativa dalla storia: {story}. "
+        f"Tonalità coerente con la personalità: {personality}."
+    )
+    if not prompt:
+        return visual_context
+    return (
+        f"{prompt}. {visual_context}" if not prompt.endswith(".") else f"{prompt} {visual_context}"
+    )
+
+
+def _enrich_video_prompt(base_prompt: str, story: str, personality: str) -> str:
+    prompt = base_prompt.strip()
+    video_context = (
+        f"Sequenza guidata dalla storia: {story}. "
+        f"Atmosfera e voce coerenti con la personalità: {personality}."
+    )
+    if not prompt:
+        return video_context
+    return (
+        f"{prompt}. {video_context}" if not prompt.endswith(".") else f"{prompt} {video_context}"
+    )
+
+
+class InfluencerContext(BaseModel):
+    influencer_id: Optional[str] = Field(
+        None,
+        description="Identificativo univoco dell'influencer registrato nello store",
+    )
+    story: Optional[str] = Field(
+        None,
+        description="Breve storia o background dell'influencer",
+    )
+    personality: Optional[str] = Field(
+        None,
+        description="Personalità e tono caratteristico dell'influencer",
+    )
+
+    @model_validator(mode="after")
+    def validate_context(self) -> "InfluencerContext":
+        has_id = bool(self.influencer_id and self.influencer_id.strip())
+        has_story = bool(self.story and self.story.strip())
+        has_personality = bool(self.personality and self.personality.strip())
+
+        if has_story != has_personality:
+            raise ValueError("story e personality devono essere fornite insieme")
+        if not has_id and not (has_story and has_personality):
+            raise ValueError(
+                "specificare influencer_id oppure fornire story e personality"
+            )
+
+        if has_id:
+            self.influencer_id = self.influencer_id.strip()
+        if has_story:
+            self.story = self.story.strip()
+            self.personality = self.personality.strip()
+        return self
+
+
+class TextGenerationRequest(InfluencerContext):
     model: str = Field(..., description="OpenRouter model identifier")
     prompt: str = Field(..., description="Prompt to send to the model")
 
@@ -31,7 +143,7 @@ class TokenUsageRequest(BaseModel):
     prompt: str = Field(..., description="Prompt to tokenize")
 
 
-class ImageGenerationRequest(BaseModel):
+class ImageGenerationRequest(InfluencerContext):
     model: str
     prompt: str
     negative_prompt: Optional[str] = Field(None, description="Negative prompt")
@@ -41,7 +153,7 @@ class ImageGenerationRequest(BaseModel):
     guidance: Optional[float] = Field(None, ge=0.0, le=50.0)
 
 
-class VideoGenerationRequest(BaseModel):
+class VideoGenerationRequest(InfluencerContext):
     model: str
     prompt: str
     duration: Optional[float] = Field(None, ge=1.0, le=60.0)
@@ -78,7 +190,11 @@ async def generate_text(
     client: OpenRouterClient = Depends(get_client),
 ) -> JSONResponse:
     try:
-        result = await client.generate_text(payload.model, payload.prompt)
+        story, personality = _resolve_influencer_context(payload)
+        enriched_prompt = _enrich_text_prompt(payload.prompt, story, personality)
+        result = await client.generate_text(payload.model, enriched_prompt)
+    except HTTPException:
+        raise
     except OpenRouterError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     finally:
@@ -106,15 +222,19 @@ async def generate_image(
     client: OpenRouterClient = Depends(get_client),
 ) -> JSONResponse:
     try:
+        story, personality = _resolve_influencer_context(payload)
+        enriched_prompt = _enrich_visual_prompt(payload.prompt, story, personality)
         data = await client.generate_image(
             model=payload.model,
-            prompt=payload.prompt,
+            prompt=enriched_prompt,
             negative_prompt=payload.negative_prompt,
             width=payload.width,
             height=payload.height,
             steps=payload.steps,
             guidance=payload.guidance,
         )
+    except HTTPException:
+        raise
     except OpenRouterError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     finally:
@@ -153,12 +273,16 @@ async def generate_video(
     client: OpenRouterClient = Depends(get_client),
 ) -> JSONResponse:
     try:
+        story, personality = _resolve_influencer_context(payload)
+        enriched_prompt = _enrich_video_prompt(payload.prompt, story, personality)
         data = await client.generate_video(
             model=payload.model,
-            prompt=payload.prompt,
+            prompt=enriched_prompt,
             duration=payload.duration,
             size=payload.size,
         )
+    except HTTPException:
+        raise
     except OpenRouterError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     finally:

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -10,11 +10,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient
 import pytest
 
-from ai_influencer.webapp.main import app, get_client
+from ai_influencer.webapp.main import INFLUENCER_STORE, app, get_client
 from ai_influencer.webapp.openrouter import OpenRouterError, summarize_models
 
 
 client = TestClient(app, raise_server_exceptions=False)
+
+DEFAULT_CONTEXT = {
+    "story": "Creatrice digitale che ama sperimentare con estetiche futuristiche.",
+    "personality": "Voce empatica e curiosa, capace di trasmettere energia positiva.",
+}
 
 
 def test_healthcheck_returns_ok_payload():
@@ -177,8 +182,10 @@ class StubVideoClient:
         self._result = result
         self._error = error
         self.closed = False
+        self.calls: list[dict] = []
 
     async def generate_video(self, **kwargs):
+        self.calls.append(kwargs)
         if self._error is not None:
             raise self._error
         return self._result
@@ -210,7 +217,7 @@ def test_generate_image_returns_remote_url_and_closes_client():
     try:
         response = client.post(
             "/api/generate/image",
-            json={"model": "stub", "prompt": "draw"},
+            json={"model": "stub", "prompt": "draw", **DEFAULT_CONTEXT},
         )
     finally:
         reset_overrides()
@@ -220,6 +227,10 @@ def test_generate_image_returns_remote_url_and_closes_client():
         "image": "https://cdn.example.com/image.png",
         "is_remote": True,
     }
+    assert len(stub_client.calls) == 1
+    prompt = stub_client.calls[0]["prompt"]
+    assert DEFAULT_CONTEXT["story"] in prompt
+    assert DEFAULT_CONTEXT["personality"] in prompt
     assert stub_client.closed is True
 
 
@@ -234,13 +245,17 @@ def test_generate_image_returns_inline_base64_and_closes_client():
     try:
         response = client.post(
             "/api/generate/image",
-            json={"model": "stub", "prompt": "draw"},
+            json={"model": "stub", "prompt": "draw", **DEFAULT_CONTEXT},
         )
     finally:
         reset_overrides()
 
     assert response.status_code == 200
     assert response.json() == {"image": inline, "is_remote": False}
+    assert len(stub_client.calls) == 1
+    prompt = stub_client.calls[0]["prompt"]
+    assert DEFAULT_CONTEXT["story"] in prompt
+    assert DEFAULT_CONTEXT["personality"] in prompt
     assert stub_client.closed is True
 
 
@@ -254,7 +269,7 @@ def test_generate_image_handles_missing_payload_and_closes_client():
     try:
         response = client.post(
             "/api/generate/image",
-            json={"model": "stub", "prompt": "draw"},
+            json={"model": "stub", "prompt": "draw", **DEFAULT_CONTEXT},
         )
     finally:
         reset_overrides()
@@ -276,7 +291,7 @@ def test_generate_image_handles_invalid_base64_and_closes_client():
     try:
         response = client.post(
             "/api/generate/image",
-            json={"model": "stub", "prompt": "draw"},
+            json={"model": "stub", "prompt": "draw", **DEFAULT_CONTEXT},
         )
     finally:
         reset_overrides()
@@ -286,32 +301,34 @@ def test_generate_image_handles_invalid_base64_and_closes_client():
     assert stub_client.closed is True
 
 
-class StubVideoClient:
-    """Minimal stub implementing the OpenRouter video client interface."""
+def test_generate_image_enriches_prompt_with_store_context():
+    stub_client = StubImageClient(
+        result={"data": [{"url": "https://cdn.example.com/store.png"}]}
+    )
 
-    def __init__(self, result=None, error: Optional[Exception] = None):
-        self._result = result
-        self._error = error
-        self.closed = False
+    async def _override() -> StubImageClient:
+        return stub_client
 
-    async def generate_video(self, **kwargs):
-        if self._error is not None:
-            raise self._error
-        return self._result
+    app.dependency_overrides[get_client] = _override
+    try:
+        response = client.post(
+            "/api/generate/image",
+            json={
+                "model": "stub",
+                "prompt": "Visionary portrait",
+                "influencer_id": "Aurora_Rise",
+            },
+        )
+    finally:
+        reset_overrides()
 
-    async def close(self):
-        self.closed = True
-
-
-def override_client(client_stub: StubVideoClient) -> None:
-    async def _get_client() -> StubVideoClient:
-        return client_stub
-
-    app.dependency_overrides[get_client] = _get_client
-
-
-def reset_overrides() -> None:
-    app.dependency_overrides.pop(get_client, None)
+    assert response.status_code == 200
+    assert stub_client.closed is True
+    assert len(stub_client.calls) == 1
+    prompt = stub_client.calls[0]["prompt"]
+    context = INFLUENCER_STORE["aurora_rise"]
+    assert context["story"] in prompt
+    assert context["personality"] in prompt
 
 
 def test_influencer_lookup_returns_enriched_media():
@@ -418,7 +435,11 @@ def test_generate_video_returns_remote_url():
     try:
         response = client.post(
             "/api/generate/video",
-            json={"model": "demo/video", "prompt": "A sunny day"},
+            json={
+                "model": "demo/video",
+                "prompt": "A sunny day",
+                **DEFAULT_CONTEXT,
+            },
         )
     finally:
         reset_overrides()
@@ -428,6 +449,10 @@ def test_generate_video_returns_remote_url():
         "video": "https://cdn.example/video.mp4",
         "is_remote": True,
     }
+    assert len(stub.calls) == 1
+    prompt = stub.calls[0]["prompt"]
+    assert DEFAULT_CONTEXT["story"] in prompt
+    assert DEFAULT_CONTEXT["personality"] in prompt
     assert stub.closed is True
 
 
@@ -437,7 +462,11 @@ def test_generate_video_returns_inline_base64_payload():
     try:
         response = client.post(
             "/api/generate/video",
-            json={"model": "demo/video", "prompt": "A futuristic city"},
+            json={
+                "model": "demo/video",
+                "prompt": "A futuristic city",
+                **DEFAULT_CONTEXT,
+            },
         )
     finally:
         reset_overrides()
@@ -447,7 +476,35 @@ def test_generate_video_returns_inline_base64_payload():
         "video": "ZmFrZS12aWRlby1kYXRh",
         "is_remote": False,
     }
+    assert len(stub.calls) == 1
+    prompt = stub.calls[0]["prompt"]
+    assert DEFAULT_CONTEXT["story"] in prompt
+    assert DEFAULT_CONTEXT["personality"] in prompt
     assert stub.closed is True
+
+
+def test_generate_video_enriches_prompt_with_store_context():
+    stub = StubVideoClient({"data": [{"url": "https://cdn.example/store-video.mp4"}]})
+    override_client(stub)
+    try:
+        response = client.post(
+            "/api/generate/video",
+            json={
+                "model": "demo/video",
+                "prompt": "Create a teaser",
+                "influencer_id": "Aurora_Rise",
+            },
+        )
+    finally:
+        reset_overrides()
+
+    assert response.status_code == 200
+    assert stub.closed is True
+    assert len(stub.calls) == 1
+    prompt = stub.calls[0]["prompt"]
+    context = INFLUENCER_STORE["aurora_rise"]
+    assert context["story"] in prompt
+    assert context["personality"] in prompt
 
 
 def test_generate_video_missing_entries_returns_error():
@@ -456,7 +513,11 @@ def test_generate_video_missing_entries_returns_error():
     try:
         response = client.post(
             "/api/generate/video",
-            json={"model": "demo/video", "prompt": "Missing entries"},
+            json={
+                "model": "demo/video",
+                "prompt": "Missing entries",
+                **DEFAULT_CONTEXT,
+            },
         )
     finally:
         reset_overrides()
@@ -472,7 +533,11 @@ def test_generate_video_with_non_dict_blob_returns_error():
     try:
         response = client.post(
             "/api/generate/video",
-            json={"model": "demo/video", "prompt": "Invalid entry"},
+            json={
+                "model": "demo/video",
+                "prompt": "Invalid entry",
+                **DEFAULT_CONTEXT,
+            },
         )
     finally:
         reset_overrides()
@@ -488,7 +553,11 @@ def test_generate_video_propagates_openrouter_errors():
     try:
         response = client.post(
             "/api/generate/video",
-            json={"model": "demo/video", "prompt": "Should fail"},
+            json={
+                "model": "demo/video",
+                "prompt": "Should fail",
+                **DEFAULT_CONTEXT,
+            },
         )
     finally:
         reset_overrides()
@@ -507,13 +576,18 @@ def test_generate_text_uses_stubbed_client_and_closes() -> None:
 
     response = client.post(
         "/api/generate/text",
-        json={"model": "meta/llama", "prompt": "Hello"},
+        json={"model": "meta/llama", "prompt": "Hello", **DEFAULT_CONTEXT},
     )
 
     try:
         assert response.status_code == 200
         assert response.json() == {"content": "expected text"}
-        assert stub.calls == [("meta/llama", "Hello")]
+        assert len(stub.calls) == 1
+        model, prompt = stub.calls[0]
+        assert model == "meta/llama"
+        assert "Hello" in prompt
+        assert DEFAULT_CONTEXT["story"] in prompt
+        assert DEFAULT_CONTEXT["personality"] in prompt
         assert stub.closed is True
     finally:
         _clear_overrides()
@@ -529,13 +603,42 @@ def test_generate_text_returns_502_on_openrouter_error() -> None:
 
     response = client.post(
         "/api/generate/text",
-        json={"model": "meta/llama", "prompt": "Hello"},
+        json={"model": "meta/llama", "prompt": "Hello", **DEFAULT_CONTEXT},
     )
 
     try:
         assert response.status_code == 502
         assert response.json() == {"detail": "stub failure"}
         assert stub.closed is True
+    finally:
+        _clear_overrides()
+
+
+def test_generate_text_enriches_prompt_with_store_context() -> None:
+    stub = StubTextClient(result="contextualized")
+
+    async def override_client() -> StubTextClient:
+        return stub
+
+    app.dependency_overrides[get_client] = override_client
+
+    response = client.post(
+        "/api/generate/text",
+        json={
+            "model": "meta/llama",
+            "prompt": "Racconta un messaggio motivazionale",
+            "influencer_id": "Aurora_Rise",
+        },
+    )
+
+    try:
+        assert response.status_code == 200
+        assert stub.closed is True
+        assert len(stub.calls) == 1
+        _, prompt = stub.calls[0]
+        context = INFLUENCER_STORE["aurora_rise"]
+        assert context["story"] in prompt
+        assert context["personality"] in prompt
     finally:
         _clear_overrides()
 


### PR DESCRIPTION
## Summary
- extend generation request payloads with influencer context fields and validate required combinations
- add reusable influencer metadata store and enrich prompts for text, image, and video requests
- expand webapp tests with stub clients to assert enriched prompts include story and personality data

## Testing
- pytest tests/test_webapp.py

------
https://chatgpt.com/codex/tasks/task_e_68d7afa1d7f48320922fcf206b27d3c3