### PR TITLE
Add package initializer for ai_influencer

### DIFF
--- a/ai_influencer/__init__.py
+++ b/ai_influencer/__init__.py
@@ -1,0 +1,10 @@
+"""Top-level package for the Influencer AI tooling.
+
+This module exposes the primary subpackages so that `import ai_influencer`
+works for both runtime code and tests without needing to know the internal
+layout of the repository.
+"""
+
+from . import scripts, webapp  # re-exported for convenient discovery
+
+__all__ = ["scripts", "webapp"]


### PR DESCRIPTION
## Summary
- add a module docstring and re-export key subpackages in `ai_influencer/__init__.py`
- ensure the package can be imported directly for tests and consumers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c4b182648320aab61b86728371f2